### PR TITLE
fix missing newline in the config

### DIFF
--- a/src/Library.pm
+++ b/src/Library.pm
@@ -574,6 +574,7 @@ sub GetFilesContents {
     while ((my $fn, my $lines_ref) = each (%{$new_lines_ref}))
     {
 	$files{$fn} = join "\n", @{$lines_ref};
+	$files{$fn} .= "\n";
     }
     return \%files;
 }


### PR DESCRIPTION
During installation, the last line is ended without newline. This
will have trouble if other sources also try to edit the config. It
would lead to a broken config that two config lines are joined in
one single line (bnc#766456) .
