### PR TITLE
use explicit target arch for GRUB2 and remove grub2-efi calls

### DIFF
--- a/src/Core/GRUB2.pm
+++ b/src/Core/GRUB2.pm
@@ -337,7 +337,11 @@ sub new
   my $loader = $self->SUPER::new($ref, $old);
   bless($loader);
 
-  $loader->milestone("Created GRUB2 instance");
+  # Do we support any architecture besides x86?
+  my $target = "i386-pc";
+  $loader->{'target'} = $target;
+
+  $loader->milestone("Created GRUB2 instance for target $target");
 
   return $loader;
 }
@@ -1246,7 +1250,7 @@ sub InitializeBootloader {
             # the tradeoff is we can't capture errors
             # only patch grub2 package is possible way
             # to get around this problem
-            "/usr/sbin/grub2-install $install_opts \"$dev\"",
+            "/usr/sbin/grub2-install --target=$self->{'target'} $install_opts \"$dev\"",
             Bootloader::Path::BootCommandLogname()
         );
 

--- a/src/Path.pm
+++ b/src/Path.pm
@@ -332,16 +332,4 @@ sub Grub2_conf {
   return Prefix($value);
 }
 
-=item
-C<< $path = Bootloader::Path::Grub2_eficonf(); >>
-
-Gets path for grub configuration file grub2-efi
-
-=cut
-
-sub Grub2_eficonf {
-  my $value = "/boot/grub2-efi/grub.cfg";
-  return Prefix($value);
-}
-
 1;


### PR DESCRIPTION
bnc#782891 unified grub2 and grub2-efi. Remove all references to
grub2-efi-\* and use explicit target argument where appropriate. After
this change GRUB2.pm is for legacy BIOS boot and GRUB2EFI.pm is for
UEFI boot. It is also possible to switch between them by explicitly
selecting bootloader type (grub2 vs. grub2-efi).

Signed-off-by: Andrey Borzenkov arvidjaar@gmail.com
