### PR TITLE
handle add and remove in update-bootloader for grub2

### DIFF
--- a/update-bootloader
+++ b/update-bootloader
@@ -219,14 +219,6 @@ if (Bootloader::Tools::GetBootloader() eq "none")
   exit 0;
 }
 
-if (Bootloader::Tools::GetBootloader() =~ /^(grub2|grub2-efi)$/)
-{
-  $logger->milestone("grub2 bootloader, no add/remove section support");
-
-  delete $oper{add};
-  delete $oper{remove};
-}
-
 if ($opt_image and $opt_image !~ m;^/;) {
     $opt_image = getcwd . '/' . $opt_image
 }
@@ -258,6 +250,28 @@ if ($opt_previous) {
     unless($opt_initrd) {
     	$opt_initrd = GetDefaultInitrd() . ".previous";
     }	
+}
+
+# grub2 handles input options differently here ..
+# when refresh, it will update both installation and config ($avoid_init=0)
+# when add or remove, only update config ($avoid_init=1)
+if (Bootloader::Tools::GetBootloader() =~ /^(grub2|grub2-efi)$/)
+{
+	if (defined $oper{refresh}) {
+	    # Always set $avoid_init=0 to guarentee bootloader installed (bnc#759224)
+	    my $ret = UpdateBootloader(0);
+	    exit 1 if ( !$ret );
+	} elsif (defined $oper{add} || defined $oper{remove}) {
+	    # The add or remove should trigger config update (bnc#780622)
+	    # Set $avoid_init=1 to avoid installing bootloader
+	    my $ret = UpdateBootloader(1);
+	    exit 1 if ( !$ret );
+	}
+
+	# clear handled option
+	delete $oper{add};
+	delete $oper{remove};
+	delete $oper{refresh};
 }
 
 # FIXME: these section names should be unified somehow together with multi


### PR DESCRIPTION
Per man page of update-bootloader, it says add or remove need to call
the refresh to take effect, but in fact it's invalid for grub or grub2
since they do not require refresh (reinstall) to get new config take
effect. Thus we'd like to change the grub2 to follow this.
1. If refresh was specified, will update config and re-install
2. If add or remove specified, update the config only

This change also verified to fix "Menu entry for memtest86+ missing in
GRUB2" (bnc#780622), as in memtest86+'s package installation calls
update-bootloader without refresh.
