### PR TITLE
fix checking wrong grub2-editenv path

### DIFF
--- a/src/Core/GRUB2.pm
+++ b/src/Core/GRUB2.pm
@@ -1111,8 +1111,8 @@ sub GetSettings {
     my $sections = $ret->{"sections"};
     my $globals = $ret->{"global"};
 
-    if (! -e "/usr/sbin/grub2-editenv") {
-        $self->warning ("file not exist /usr/sbin/grub2-editenv");
+    if (! -e "/usr/bin/grub2-editenv") {
+        $self->warning ("file not exist /usr/bin/grub2-editenv");
         return $ret;
     }
 

--- a/src/Core/GRUB2EFI.pm
+++ b/src/Core/GRUB2EFI.pm
@@ -703,8 +703,8 @@ sub GetSettings {
     my $sections = $ret->{"sections"};
     my $globals = $ret->{"global"};
 
-    if (! -e "/usr/sbin/grub2-editenv") {
-        $self->warning ("file not exist /usr/sbin/grub2-editenv");
+    if (! -e "/usr/bin/grub2-editenv") {
+        $self->warning ("file not exist /usr/bin/grub2-editenv");
         return $ret;
     }
 


### PR DESCRIPTION
fix checking wrong grub2-editenv path, it's not executed at all and
caused default menu entry not determined. (bnc#861469)
