### PR TITLE
enable SUSE_BTRFS_SNAPSHOT_BOOTING only on i386-pc

### DIFF
--- a/perl-Bootloader.changes
+++ b/perl-Bootloader.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Apr  1 09:43:57 UTC 2014 - mchang@suse.com
+
+- enable SUSE_BTRFS_SNAPSHOT_BOOTING on x86 as other architectures
+  are working in progress.
+- 0.808  
+
+-------------------------------------------------------------------
 Mon Mar 31 12:18:44 UTC 2014 - mchang@suse.com
 
 - support snapper rollback (fate##317062)

--- a/src/Core/GRUB2.pm
+++ b/src/Core/GRUB2.pm
@@ -985,7 +985,12 @@ sub Info2Global {
     my $distributor = delete $globinfo{"distributor"} || "";
     my $append_failsafe = delete $globinfo{"append_failsafe"} || "";
     my $os_prober = delete $globinfo{"os_prober"} || "";
-    my $suse_btrfs = delete $globinfo{"suse_btrfs"} || "true";
+    my $suse_btrfs = delete $globinfo{"suse_btrfs"} || "";
+    # enable btrfs snapshot boot configs only on i386-pc
+    # other architectures (s390, ppc) are planned but not ready 
+    if ($self->{'target'} eq "i386-pc") {
+        $suse_btrfs = "true";
+    }
     # $root = " root=$root" if $root ne "";
     $vga = " vga=$vga" if $vga ne "";
     $append = " $append" if $append ne "";
@@ -1348,6 +1353,8 @@ sub InitializeBootloader {
             }
 
             if ($glob{suse_btrfs} eq "true" and -e "/usr/sbin/suse_btrfs_grub2_install.sh") {
+                # enable btrfs snapshot boot configs only on i386-pc
+                # other architectures (s390, ppc) are planned but not ready
                 if ($self->{'target'} eq "i386-pc") {
                     my $rootfs = qx(/usr/sbin/grub2-probe -t fs /);
                     my $bootfs = qx(/usr/sbin/grub2-probe -t fs /boot);


### PR DESCRIPTION
enable SUSE_BTRFS_SNAPSHOT_BOOTING on i386-pc and not on other
architectures (s390, ppc) the ensure their config not affected. Also
make comments as suggested by jredinger.
