### PR TITLE
Add armv7l support for grub2

### DIFF
--- a/src/Core/GRUB2EFI.pm
+++ b/src/Core/GRUB2EFI.pm
@@ -218,6 +218,8 @@ sub new
         $machine = "x86_64";
     } elsif ($machine eq "aarch64") {
         $machine = "arm64";
+    } elsif ($machine eq "armv7l") {
+        $machine = "arm";
     }
     my $target = "$machine-efi";
     $loader->{'target'} = $target;


### PR DESCRIPTION
We have at least one armv7l EFI machine that runs EFI grub2. Enable
the grub2 installation code to handle the translation from "armv7l" (uname)
to "arm" (grub2 name)

Signed-off-by: Alexander Graf agraf@suse.de
