### PR TITLE
config file sections with no keys should not match (bnc #913631)

### DIFF
--- a/src/Tools.pm
+++ b/src/Tools.pm
@@ -941,7 +941,7 @@ sub match_section
   my $self = $lib_ref;
 
   my ($sect_ref, $opt_ref) = @_;
-  my $match = 1;
+  my $match = 0;
 
   $self->milestone("section name: \"$sect_ref->{name}\"");
 


### PR DESCRIPTION
Change the default to 'not matching'. That is, sections with no comparable keys don't match.