### PR TITLE
Determine disk device from sysfs tree

### DIFF
--- a/src/Core/GRUB2.pm
+++ b/src/Core/GRUB2.pm
@@ -126,8 +126,11 @@ sub GetDeviceMap {
             }
         }
 
-        # skip partitions, assume they were ended with digits
-        if ($kern_dev =~ /\d+$/) {
+        my $sys_dev = $kern_dev;
+        $sys_dev =~ s#^/dev/##;
+        $sys_dev =~ s#/#!#g;
+        $sys_dev = "/sys/block/$sys_dev";
+        if ( ! -d $sys_dev ) {
             $self->milestone ("skip partition $kern_dev in device map");
             next GETMAP;
         }


### PR DESCRIPTION
Determine disk device from sysfs tree (bsc#911584).