### PR TITLE
Initialize GRUB_USE_LINUXEFI from secure_boot setting

### DIFF
--- a/src/Core/GRUB2EFI.pm
+++ b/src/Core/GRUB2EFI.pm
@@ -551,7 +551,7 @@ sub Info2Global {
             },
             {
                 'key' => 'GRUB_USE_LINUXEFI',
-                'value' => 'true',
+                'value' => ($self->{'target'} =~ /i386|x86_64/ ? 'true' : 'false'),
             },
             {
                 'key' => 'SUSE_BTRFS_SNAPSHOT_BOOTING',


### PR DESCRIPTION
linuxefi only exists on x86_64, it should not be used on other architectures, like aarch64, which don't set secure_boot.