### PR TITLE
Escape dollar signs (bsc#857556)

### DIFF
--- a/perl-Bootloader-testsuite/tests/test_interface/core-test.pl
+++ b/perl-Bootloader-testsuite/tests/test_interface/core-test.pl
@@ -1,5 +1,5 @@
 use strict;
-use Test::More tests => 14;
+use Test::More tests => 16;
 
 use lib "./";
 use Bootloader::Library;
@@ -18,7 +18,8 @@ my @test_strings = (
     ['acpi_osi="!Windows 2012"', '"acpi_osi=\"!Windows 2012\""'],
     ['acpi_osi=\"!Windows 2012\"', '"acpi_osi=\\\\\"!Windows 2012\\\\\""'],
     ['`echo Hello`', '`echo Hello`'],
-    ['Hello `pwd`', '"Hello \`pwd\`"']
+    ['Hello `pwd`', '"Hello \`pwd\`"'],
+    ['Hello $PWD', '"Hello \$PWD"']
     );
 
 foreach(  @test_strings ) {

--- a/src/Core.pm
+++ b/src/Core.pm
@@ -330,7 +330,7 @@ sub Quote {
     $text = $self->trim($text);
     return $text if ($text =~ /^`.*`$/); #leave full strings in backticks untouched
 
-    $text =~ s/([\\"`])/\\$1/g; #escape backslashes, backticks and quotes
+    $text =~ s/([\\"`\$])/\\$1/g; #escape backslashes, backticks, dollars and quotes
 
     if ($when eq "always"
 	|| ($when eq "blanks" && index ($text, " ") >= 0)
@@ -364,7 +364,7 @@ sub Unquote {
 	$text = $1;
     }
 
-    $text =~ s/\\([\\"`])/$1/g; #unescape backslashes, backticks and quotes
+    $text =~ s/\\([\\"`\$])/$1/g; #unescape backslashes, backticks, dollars and quotes
 
     return $text;
 }


### PR DESCRIPTION
The bug report actually suggests to 3-fold escape the dollar signs. For now I cannot see why.
What perl-Bootloader does is writing /etc/default/grub, which is a shell script. For properly escaping there it should be enough to ad just one backslash, IMO.