### PR TITLE
strip superfluous "/boot" parts of path if there's a boot -> '.' comp…

### DIFF
--- a/src/Core/GRUB.pm
+++ b/src/Core/GRUB.pm
@@ -675,9 +675,14 @@ sub GrubPath2UnixPath {
 	return $orig_path;
     }
 
+    # strip superfluous "/boot" parts of path if there's a boot -> '.' compat link
+    if(-d($mountpoint) && readlink("$mountpoint/boot") eq '.') {
+      $path =~ s#^(/boot)+/#/#;
+    }
+
     $path = $mountpoint . $path;
     $path = $self->CanonicalPath ($path);
-    $self->debug("Translated GRUB->UNIX dev: $dev, path: $orig_path to: $path");
+    $self->milestone("Translated GRUB->UNIX dev: $dev, path: $orig_path to: $path");
     return $path;
 }
 


### PR DESCRIPTION
…at link (bsc #956885)

If we don't do this, section matching might not work as the paths can look
different although they are technically identical.

But don't overdo this and just handle the boot -> '.' link in the boot
partition we add to ease peoples lives.