### PR TITLE
added support for modifying default boot options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,16 +36,26 @@ install: check
 	@install -d -m 755 $(DESTDIR)/usr/lib/bootloader
 	@install -m 755 bootloader_entry $(DESTDIR)/usr/lib/bootloader/bootloader_entry.old
 	@install -m 755 update-bootloader $(DESTDIR)/usr/lib/bootloader/update-bootloader.old
+
 	@install -d -m 755 $(DESTDIR)/usr/lib/bootloader/grub2
 	@install -m 755 grub2/install $(DESTDIR)/usr/lib/bootloader/grub2
 	@install -m 755 grub2/config $(DESTDIR)/usr/lib/bootloader/grub2
+	@install -m 755 grub2/add-option $(DESTDIR)/usr/lib/bootloader/grub2
+	@install -m 755 grub2/del-option $(DESTDIR)/usr/lib/bootloader/grub2
+
 	@install -d -m 755 $(DESTDIR)/usr/lib/bootloader/grub2-efi
 	@install -m 755 grub2-efi/install $(DESTDIR)/usr/lib/bootloader/grub2-efi
 	@install -m 755 grub2/config $(DESTDIR)/usr/lib/bootloader/grub2-efi
-	@install -m 755 pbl $(DESTDIR)/usr/lib/bootloader/pbl
-	@perl -pi -e 's/0\.0/$(VERSION)/ if /VERSION = /' $(DESTDIR)/usr/lib/bootloader/pbl
-	@ln -snf ../usr/lib/bootloader/pbl $(DESTDIR)/sbin/update-bootloader
-	@ln -snf pbl $(DESTDIR)/usr/lib/bootloader/bootloader_entry
+	@install -m 755 grub2/add-option $(DESTDIR)/usr/lib/bootloader/grub2-efi
+	@install -m 755 grub2/del-option $(DESTDIR)/usr/lib/bootloader/grub2
+
+	@install -d -m 755 $(DESTDIR)/usr/lib/bootloader/uboot
+	@install -m 755 grub2/config $(DESTDIR)/usr/lib/bootloader/uboot
+
+	@install -m 755 pbl $(DESTDIR)/sbin/pbl
+	@perl -pi -e 's/0\.0/$(VERSION)/ if /VERSION = /' $(DESTDIR)/sbin/pbl
+	@ln -snf pbl $(DESTDIR)/sbin/update-bootloader
+	@ln -snf ../../../sbin/pbl $(DESTDIR)/usr/lib/bootloader/bootloader_entry
 	@install -d -m 755 $(DESTDIR)/boot
 	@install -m 644 boot.readme $(DESTDIR)/boot/
 	@install -d -m 755 $(DESTDIR)/usr/share/man/man8/

--- a/grub2/add-option
+++ b/grub2/add-option
@@ -1,0 +1,52 @@
+#! /usr/bin/perl
+
+# usage: add-option OPTION
+#
+# Modify default boot option (resp. add it).
+#
+# OPTION is either of the form 'key=value' or 'key="value"' or just 'key'.
+
+use strict;
+
+my $file = "/etc/default/grub";
+
+my $opt = shift;
+
+my $opt_name = $opt;
+
+if($opt_name =~ s/=("?).*//) {
+  $opt =~ s/"/\\"/g;
+}
+
+exit 1 if $opt_name eq "";
+
+open my $f, $file or die "$file: $!\n";
+my @lines = (<$f>);
+close $f;
+
+my $changed = 0;
+
+for (@lines) {
+  if(/^(GRUB_CMDLINE_LINUX_DEFAULT)=(.*)/) {
+    $changed = 1;
+    my $key = $1;
+    my $val = $2;
+
+    $val =~ s/(^"\s*|\s*"\s*$)//g;
+
+    $val =~ s/(^|\s)$opt_name=(\\"[^"]*\\"\s*)/ $opt / or
+    $val =~ s/(^|\s)$opt_name((\s|$)|(=\S*\s*))/ $opt / or
+    $val .= " $opt";
+
+    $_ = "$key=\"$val\"\n";
+  }
+}
+
+exit 0 unless $changed;
+
+open my $f, ">$file.pblnew" or die "$file.pblnew: $!\n";
+print $f @lines;
+close $f;
+
+rename "$file.pblnew", $file;
+

--- a/grub2/del-option
+++ b/grub2/del-option
@@ -1,0 +1,49 @@
+#! /usr/bin/perl
+
+# usage: del-option OPTION
+#
+# Delete default boot option.
+#
+# OPTION is either of the form 'key=value' or 'key="value"' or just 'key'.
+
+use strict;
+
+my $file = "/etc/default/grub";
+
+my $opt = shift;
+
+$opt =~ s/=("?).*//;
+
+exit 1 if $opt eq "";
+
+open my $f, $file or die "$file: $!\n";
+my @lines = (<$f>);
+close $f;
+
+my $changed = 0;
+
+for (@lines) {
+  if(/^(GRUB_CMDLINE_LINUX_DEFAULT)=(.*)/) {
+    $changed = 1;
+    my $key = $1;
+    my $val = $2;
+
+    $val =~ s/(^"\s*|\s*"\s*$)//g;
+
+    $val =~ s/(^|\s)$opt=(\\"[^"]*\\"\s*)/ / or
+    $val =~ s/(^|\s)$opt((\s|$)|(=\S*\s*))/ /;
+
+    $val =~ s/\s*$//;
+
+    $_ = "$key=\"$val\"\n";
+  }
+}
+
+exit 0 unless $changed;
+
+open my $f, ">$file.pblnew" or die "$file.pblnew: $!\n";
+print $f @lines;
+close $f;
+
+rename "$file.pblnew", $file;
+

--- a/grub2/install
+++ b/grub2/install
@@ -18,7 +18,7 @@ echo "target = $target"
 err=0
 
 if [ -x /usr/sbin/grub2-install ] ; then
-  if [ -f /etc/default/grub_installdevice ] ; then
+  if [ -r /etc/default/grub_installdevice ] ; then
     while read foo ; do
       # ignore everything that doesn't look like a path
       [ "${foo::1}" != "/" ] && continue
@@ -30,7 +30,7 @@ if [ -x /usr/sbin/grub2-install ] ; then
       fi
     done </etc/default/grub_installdevice
   else
-    echo "/etc/default/grub_installdevice: no such file"
+    echo "/etc/default/grub_installdevice: permission denied"
     err=1
   fi
 else

--- a/pbl
+++ b/pbl
@@ -18,6 +18,7 @@
 use strict;
 use POSIX qw ( strftime uname );
 
+use Getopt::Long;
 use Data::Dumper;
 $Data::Dumper::Sortkeys = 1;
 $Data::Dumper::Terse = 1;
@@ -27,8 +28,9 @@ my $VERSION = "0.0";
 
 my $pbl_dir = "/usr/lib/bootloader";
 
+sub pbl_usage;
 sub new;
-sub info;
+sub log_msg;
 sub get_bootloader;
 sub run_command;
 
@@ -38,25 +40,51 @@ my $loader;
 my $exit_code = 0;
 my @todo;
 
+my $opt_logfile = "/var/log/pbl.log";
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# pbl_usage($exit_code)
+#
+# Print help text and exit.
+#
+sub pbl_usage
+{
+  print <<"= = = = = = = =";
+Usage: pbl [OPTIONS]
+Configure/install boot loader.
+
+Options:
+    --install               Install boot loader.
+    --config                Create boot loader config.
+    --show                  Print current boot loader name.
+    --default ENTRY         Set default boot entry to ENTRY.
+    --add-option OPTION     Add OPTION to default boot options.
+    --del-option OPTION     Delete OPTION from default boot options.
+    --log LOGFILE           Log messages to LOGFILE (default: /var/log/pbl.log)
+    --version               Show pbl version.
+    --help                  Write this help text.
+
+= = = = = = = =
+
+  exit shift;
+}
+
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub new
 {
   $log->{session_id} = $program . sprintf("-%04d", int rand 10000);
 
-  # log to logfile if we can, else to STDERR
+  # log to logfile if we can
 
-  if(open my $f, ">>/var/log/pbl.log") {
+  if(open my $f, ">>$opt_logfile") {
     my $tmp = select $f;
     $| = 1;
     select $tmp;
     binmode $f, ':utf8';
     $log->{log_fh} = $f;
-  }
-  elsif(open my $f, ">&STDERR") {
-    binmode $f, ':utf8';
-    $log->{log_fh} = $f;
-    $log->{log_is_stderr} = 1;
+    $log->{log_is_tty} = 1 if $opt_logfile eq '-';
   }
 
   # find root device & detect if we are chroot-ed
@@ -73,14 +101,14 @@ sub new
     }
   }
 
-  info(1, "$log->{session_id} = $0, version = $VERSION, root = $r");
+  log_msg(1, "$log->{session_id} = $0, version = $VERSION, root = $r");
 }
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-# info(level, message, var, depth)
+# log_msg(level, message, var, depth)
 #
-# level: 0 .. 3 (debug, info, warning, error)
+# level: 0 .. 3 (debug, log_msg, warning, error)
 # message: log message (single line string)
 # var (optional): either a SCALAR or a REF
 #   - SCALAR (may be multiline) will be logged in a block delimited
@@ -88,7 +116,7 @@ sub new
 #   - REF will be logged using Data::Dumper
 # depth (optional): maximum depth when logging a REF
 #
-sub info
+sub log_msg
 {
   my $level = shift;
   my $message = shift;
@@ -129,9 +157,9 @@ sub info
     print { $log->{log_fh} } "$prefix $message\n";
   }
 
-  # log error messages to STDERR unless we already did
+  # log error messages to console unless we already did
 
-  if(!$log->{log_is_stderr} && $level > 2) {
+  if(!$log->{log_is_tty} && $level > 2) {
     print STDERR "$program: $prefix $message\n";
   }
 }
@@ -158,31 +186,30 @@ sub get_bootloader
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub run_command
 {
-  my $command = shift;
-  my $try = shift;
-
   my $ret;
   my $output;
 
-  if(open my $f, "($command) 2>&1 |") {
+  my $command = join " ", @_;
+
+  if(open my $f, "-|") {
     local $/;
     $output = <$f>;
     close $f;
     $ret = $? >> 8;
-    chomp $output;
-    $output .= "\n";
   }
   else {
-    $ret = 127;
-    $output = "$command: " . ($! == 13 ? $! : "command not found") . " \n";
+    open STDERR, ">&STDOUT";
+    exec @_;
+    exit 127;
   }
 
-  if(!$ret || $try) {
-    info(1, "'$command' = $ret, output:", $output);
-    $ret = 0;
+  $output = "$command: " . ($! == 13 ? $! : "command not found") . " \n" if $ret == 127;
+
+  if(!$ret) {
+    log_msg(1, "'$command' = $ret, output:", $output);
   }
   else {
-    info(3, "'$command' failed with exit code $ret, output:", $output);
+    log_msg(3, "'$command' failed with exit code $ret, output:", $output);
   }
 
   return $ret;
@@ -192,31 +219,49 @@ sub run_command
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ($program = $0) =~ s#^.*/##;
 
-info(1, join(' ', ($0, @ARGV)));
-
 $loader = get_bootloader;
 
-info(1, "bootloader = $loader");
+if($program eq 'pbl') {
+  GetOptions(
+    'log=s'        => \$opt_logfile,
+    'install'      => sub { push @todo, [ 'install' ] },
+    'config'       => sub { push @todo, [ 'config' ] },
+    'show'         => sub { print "$loader\n"; exit 0 },
+    'default=s'    => sub { push @todo, [ 'default', $_[1] ] },
+    'add-option=s' => sub { push @todo, [ 'add-option', $_[1] ] },
+    'del-option=s' => sub { push @todo, [ 'del-option', $_[1] ] },
+    'version'      => sub { print "$VERSION\n"; exit 0 },
+    'help'         => sub { pbl_usage 0 },
+  ) || pbl_usage 1;
+}
+
+log_msg(1, join(' ', ($0, @ARGV)));
+
+log_msg(1, "bootloader = $loader");
 
 exit 0 if !$loader;
 
-push @todo, 'config';
-
-unshift @todo, 'install' if grep { /^--reinit$/ } @ARGV;
+if($program ne 'pbl') {
+  # compat: update-bootloader or bootloader_entry
+  push @todo, [ 'config' ];
+  unshift @todo, [ 'install' ] if grep { /^--reinit$/ } @ARGV;
+}
 
 if(-d "$pbl_dir/$loader") {
   for (@todo) {
-    if(-x "$pbl_dir/$loader/$_") {
-      $exit_code = run_command("$pbl_dir/$loader/$_") || $exit_code;
+    my @cmd = @{$_};
+    $cmd[0] = "$pbl_dir/$loader/$cmd[0]";
+    if(-x $cmd[0]) {
+      $exit_code = run_command(@cmd) || $exit_code;
     }
     else {
-      info(1, "$loader::$_ skipped");
+      log_msg(1, "$cmd[0] skipped");
     }
   }
 }
 else {
   exec "/usr/lib/bootloader/$program.old", @ARGV;
-  info(3, "/usr/lib/bootloader/$program.old: command not found");
+  log_msg(3, "/usr/lib/bootloader/$program.old: command not found");
   $exit_code = 1;
 }
 


### PR DESCRIPTION
I've re-arranged the package layout a bit. There's now a 'pbl' tool with
its own set of options.

update-bootloader and bootloader_entry are just symlinks to it.

'pbl --ACTION' basically maps to running /usr/lib/bootloader/<LOADER>/ACTION.
Some pbl options need an argument. If so, it's passed as argument to the
ACTION script.