### PR TITLE
Fix parsing of /etc/default/grub

### DIFF
--- a/src/Core/GRUB2.pm
+++ b/src/Core/GRUB2.pm
@@ -466,7 +466,7 @@ sub ParseLines {
     # need to process saparately
     foreach my $conf (@defaultconf) {
         if ($conf =~ m/^\s*#\s*GRUB_/) {
-            $conf =~ s/^\s*#/@/;
+            $conf =~ s/^\s*#\s*/@/;
         }
     }
 

--- a/src/Core/GRUB2EFI.pm
+++ b/src/Core/GRUB2EFI.pm
@@ -275,7 +275,7 @@ sub ParseLines {
     # need to process saparately
     foreach my $conf (@defaultconf) {
         if ($conf =~ m/^\s*#\s*GRUB_/) {
-            $conf =~ s/^\s*#/@/;
+            $conf =~ s/^\s*#\s*/@/;
         }
     }
 


### PR DESCRIPTION
Fix for boo#965499:

The replacement "#GRUB_*" to "@GRUB_*" (commented config) causes parsing to fail if there is whitespace between # and the key, e.g. "# GRUB_DISTRIBUTOR".
Remove whitespace from commented config options to not cause parsing to return an invalid result.