### PR TITLE
Skip grub2-install on PowerNV

### DIFF
--- a/grub2/install
+++ b/grub2/install
@@ -9,12 +9,15 @@ fi
 
 case "$target" in
   i?86 | x86_64 ) target=i386-pc ;;
-  ppc | ppc64 ) target=powerpc-ieee1275 ;;
+  ppc | ppc64* ) target=powerpc-ieee1275 ;;
   s390x ) target=s390x-emu ;;
 esac
 
 echo "target = $target"
 
+if [ "$target" = "powerpc-ieee1275" ];
+  grep -q PowerNV /proc/cpuinfo && exit 0
+fi
 err=0
 
 if [ -x /usr/sbin/grub2-install ] ; then


### PR DESCRIPTION
PowerNV platform doesn't have PReP device, it is sufficient
to just generate a grub2.cfg

Signed-off-by: Dinar Valeev <dvaleev@suse.com>