### PR TITLE
Don't install grub2-efi during installation (bsc#979145)

### DIFF
--- a/grub2-efi/install
+++ b/grub2-efi/install
@@ -18,6 +18,12 @@ target="$target-efi"
 
 echo "target = $target"
 
+# We install grub2 at the end of the installation, not within (bsc#979145)
+if [ "$YAST_IS_RUNNING" = instsys ]; then
+	echo "Skipping grub2-efi during installation. Will be done at the end"
+	exit 0
+fi
+
 # EFI has 2 boot paths. The default is that there is a target file listed in
 # the boot list. The boot list is stored in NVRAM and exposed as efivars.
 #

--- a/grub2/install
+++ b/grub2/install
@@ -15,6 +15,12 @@ esac
 
 echo "target = $target"
 
+# We install grub2 at the end of the installation, not within (bsc#979145)
+if [ "$YAST_IS_RUNNING" = instsys ]; then
+	echo "Skipping grub2 during installation. Will be done at the end"
+	exit 0
+fi
+
 if [ "$target" = "powerpc-ieee1275" ] ; then
   grep -q PowerNV /proc/cpuinfo && exit 0
 fi


### PR DESCRIPTION
I have a hard time actually testing this. Could you please assemble an installation DVD with this fixed package, install it using EFI on x86_64 and then check that there is nothing in /boot/efi/EFI/BOOT?