### PR TITLE
ensure trusted boot setting is used (fate #316553)

### DIFF
--- a/grub2-efi/install
+++ b/grub2-efi/install
@@ -1,5 +1,12 @@
 #! /bin/bash
 
+# Settings from /etc/sysconfig/filename are available as environment vars
+# with the name 'SYS__FILENAME__KEY' (filename converted to upper case).
+#
+# Not all files are parsed, current list is:
+#   bootloader, language
+#
+
 target=$(uname --hardware-platform)
 
 if [ -z "$target" ] ; then

--- a/grub2/config
+++ b/grub2/config
@@ -1,5 +1,12 @@
 #! /bin/bash
 
+# Settings from /etc/sysconfig/filename are available as environment vars
+# with the name 'SYS__FILENAME__KEY' (filename converted to upper case).
+#
+# Not all files are parsed, current list is:
+#   bootloader, language
+#
+
 if [ -x /usr/sbin/grub2-mkconfig ] ; then
   if [ -d /boot/grub2 ] ; then
     ( set -x ; /usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg )

--- a/grub2/install
+++ b/grub2/install
@@ -1,5 +1,12 @@
 #! /bin/bash
 
+# Settings from /etc/sysconfig/filename are available as environment vars
+# with the name 'SYS__FILENAME__KEY' (filename converted to upper case).
+#
+# Not all files are parsed, current list is:
+#   bootloader, language
+#
+
 target=$(uname --hardware-platform)
 
 if [ -z "$target" ] ; then
@@ -24,8 +31,12 @@ fi
 if [ "$target" = "powerpc-ieee1275" ] ; then
   grep -q PowerNV /proc/cpuinfo && exit 0
 fi
-err=0
 
+if [ "$SYS__BOOTLOADER__TRUSTED_BOOT" = yes -a -d "/usr/lib/trustedgrub2/$target" ] ; then
+  trusted="--directory=/usr/lib/trustedgrub2/$target"
+fi
+
+err=0
 if [ -x /usr/sbin/grub2-install ] ; then
   if [ "$needs_installdevice" = 1 ] ; then
     if [ -r /etc/default/grub_installdevice ] ; then
@@ -33,7 +44,7 @@ if [ -x /usr/sbin/grub2-install ] ; then
         # ignore everything that doesn't look like a path
         [ "${device::1}" != "/" ] && continue
         if [ -b "$device" -o -f "$device" ] ; then
-          ( set -x ; /usr/sbin/grub2-install --target="$target" --force --skip-fs-probe "$device" ) || err=1
+          ( set -x ; /usr/sbin/grub2-install $trusted --target="$target" --force --skip-fs-probe "$device" ) || err=1
         else
           echo "$device: not a block device"
           err=1
@@ -44,7 +55,7 @@ if [ -x /usr/sbin/grub2-install ] ; then
       err=1
     fi
   else
-    ( set -x ; /usr/sbin/grub2-install --target="$target" )
+    ( set -x ; /usr/sbin/grub2-install $trusted --target="$target" )
   fi
 else
   echo "grub2-install: command not found"

--- a/pbl
+++ b/pbl
@@ -31,8 +31,8 @@ my $pbl_dir = "/usr/lib/bootloader";
 sub pbl_usage;
 sub new;
 sub log_msg;
-sub get_bootloader;
 sub run_command;
+sub read_sysconfig;
 
 my $program;
 my $log;
@@ -166,24 +166,6 @@ sub log_msg
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-sub get_bootloader
-{
-  my $bl;
-
-  if(open my $f, "/etc/sysconfig/bootloader") {
-    while(<$f>) {
-      $bl = $1, last if /^LOADER_TYPE=(\S*)/;
-    }
-    close $f;
-  }
-
-  $bl =~ s/^["']|["']$//g;
-
-  return $bl;
-}
-
-
-# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 sub run_command
 {
   my $ret;
@@ -192,6 +174,7 @@ sub run_command
   my $command = join " ", @_;
 
   if(open my $f, "-|") {
+    binmode $f, ':utf8';
     local $/;
     $output = <$f>;
     close $f;
@@ -216,9 +199,38 @@ sub run_command
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# read_sysconfig(FILENAME)
+#
+# Read sysconfig settings and convert them into environment vars of the form:
+#
+# SYS__FILENAME__KEY=value
+#
+sub read_sysconfig
+{
+  my $file = $_[0];
+
+  if(open my $f, "/etc/sysconfig/$file") {
+    while(<$f>) {
+      if(/^([A-Z_]+)=(.*?)\s*$/) {
+        my $key = $1;
+        my $val = $2;
+        $val =~ s/^(["'])(.*)\1$/$2/g;
+        $ENV{"SYS__\U$file\E__$key"} = $val;
+      }
+    }
+    close $f;
+  }
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ($program = $0) =~ s#^.*/##;
 
-$loader = get_bootloader;
+# get settings relevant for us
+read_sysconfig "bootloader";
+read_sysconfig "language";
+
+$loader = $ENV{SYS__BOOTLOADER__LOADER_TYPE};
 
 if($program eq 'pbl') {
   GetOptions(

--- a/u-boot/config
+++ b/u-boot/config
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Settings from /etc/sysconfig/filename are available as environment vars
+# with the name 'SYS__FILENAME__KEY' (filename converted to upper case).
+#
+# Not all files are parsed, current list is:
+#   bootloader, language
+#
+
 function print_entry {
 	local label=$1
 	local zimage=$2


### PR DESCRIPTION
YaST puts the current state into /etc/sysconfig/bootloader::TRUSTED_BOOT.
When it's set to 'yes' and trustedgrub2 is installed, use trustedgrub2.

This patch also makes a number of sysconfig settings available to the
bootloader scripts.