### PR TITLE
run grub in RC_LANG locale taken from sysconfig (bsc #985946)

### DIFF
--- a/pbl
+++ b/pbl
@@ -252,6 +252,13 @@ log_msg(1, "bootloader = $loader");
 
 exit 0 if !$loader;
 
+my $lang = $ENV{SYS__LANGUAGE__RC_LANG};
+if(defined $lang) {
+  log_msg(1, "locale = $lang");
+  delete $ENV{LC_MESSAGES};
+  $ENV{LANG} = $lang;
+}
+
 if($program ne 'pbl') {
   # compat: update-bootloader or bootloader_entry
   push @todo, [ 'config' ];

--- a/pbl
+++ b/pbl
@@ -256,6 +256,7 @@ my $lang = $ENV{SYS__LANGUAGE__RC_LANG};
 if(defined $lang) {
   log_msg(1, "locale = $lang");
   delete $ENV{LC_MESSAGES};
+  delete $ENV{LC_ALL};
   $ENV{LANG} = $lang;
 }
 


### PR DESCRIPTION
To avoid grub menu settings switching languages depending on how exactly a
(for example) kernel update was run, we tie it to the RC_LANG setting from
/etc/sysconfig/language.