### PR TITLE
grub2: parse initrd (bsc#1007335)

### DIFF
--- a/src/Core/GRUB2.pm
+++ b/src/Core/GRUB2.pm
@@ -365,6 +365,9 @@ sub GrubCfgSections {
 
                     $sect_info{"append"} = $append;
                 }
+                if ($cfg2 =~ /^\s+initrd\s+(\S+)\s*$/m) {
+                    $sect_info{"initrd"} = $1;
+                }
             }
 
             push @{$sect}, \%sect_info;


### PR DESCRIPTION
fixes https://bugzilla.suse.com/show_bug.cgi?id=1007335