### PR TITLE
work without /etc/default/grub_installdevice

### DIFF
--- a/grub2/install
+++ b/grub2/install
@@ -44,6 +44,24 @@ function partition_to_disk
 }
 
 
+# Usage: first_slave(disk)
+#
+# Find first slave device for disk.
+#
+# Return empty string if there are no slaves.
+#
+function first_slave
+{
+  local dev=$(echo /sys/block/$1/slaves/*)
+  dev=${dev%% *}
+  dev=${dev##*/}
+
+  [ "$dev" = "*" ] && dev=
+
+  echo $dev
+}
+
+
 # Usage: disk_device(arg)
 #
 # Find disk device name for arg.
@@ -56,6 +74,7 @@ function disk_device
 {
   local part
   local dev
+  local dev1
 
   if [ "${1#/dev/}" = "$1" ] ; then
     while read part ; do
@@ -69,22 +88,31 @@ function disk_device
   [ -n "$part" ] && part=${part#/dev/}
   [ -z "$part" ] && exit
 
-  echo "partition = $part" >&2
+  echo "kernel device = $part" >&2
 
-  dev=$(partition_to_disk $part)
+  dev=$part
 
-  if [ -z "$dev" ] ; then
-    dev=$(echo /sys/block/$part/slaves/*)
-    # use only the first device atm
-    dev=${dev%% *}
-    dev=${dev##*/}
-
-    if [ -z "$(is_disk $dev)" ] ; then
-      dev=$(partition_to_disk $dev)
+  while true ; do
+    dev1=$(partition_to_disk $dev)
+    if [ -n "$dev1" ] ; then
+      echo "disk($dev) = $dev1" >&2
+      dev=$dev1
     fi
-  fi
 
-  echo "device = $dev" >&2
+    # $dev is a disk but not a partition
+
+    dev1=$(first_slave $dev)
+
+    if [ -n "$dev1" ] ; then
+      echo "slave($dev) = $dev1" >&2
+      dev=$dev1
+      continue
+    fi
+
+    break
+  done
+
+  echo "disk = $dev" >&2
 
   echo $dev
 }

--- a/grub2/install
+++ b/grub2/install
@@ -7,6 +7,89 @@
 #   bootloader, language
 #
 
+# Usage: is_disk(disk)
+#
+# Return disk if disk is a disk device (not a partition), else "".
+# Disk name is without leading '/dev/'.
+#
+function is_disk
+{
+  local dev=$1
+
+  if [ -d "/sys/block/$dev" -a -b "/dev/$dev" ] ; then
+    echo $dev
+  fi
+}
+
+
+# Usage: partition_to_disk(partition)
+#
+# Find disk device name for a partition.
+# Partition and disk name are without leading '/dev/'.
+#
+# Return empty string if there is no parent disk device for a partition.
+#
+function partition_to_disk
+{
+  local part=$1
+  local dev=$(echo /sys/block/*/$part)
+  # there should normally be just one entry - but better make sure
+  dev=${dev%% *}
+
+  if [ -d "$dev" ] ; then
+    dev=${dev#/sys/block/}
+    dev=${dev%/$part}
+    [ -b "/dev/$dev" ] && echo $dev
+  fi
+}
+
+
+# Usage: disk_device(arg)
+#
+# Find disk device name for arg.
+# arg may be a partition name or a directory
+# Disk name is without leading '/dev/'.
+#
+# Return empty string if a disk device could not be found.
+#
+function disk_device
+{
+  local part
+  local dev
+
+  if [ "${1#/dev/}" = "$1" ] ; then
+    while read part ; do
+      [ "${part::1}" = "/" ] && break
+    done < <(df --local --sync --output=source $1)
+  else
+    part=$1
+  fi
+
+  [ -n "$part" ] && part=$(readlink -e $part)
+  [ -n "$part" ] && part=${part#/dev/}
+  [ -z "$part" ] && exit
+
+  echo "partition = $part" >&2
+
+  dev=$(partition_to_disk $part)
+
+  if [ -z "$dev" ] ; then
+    dev=$(echo /sys/block/$part/slaves/*)
+    # use only the first device atm
+    dev=${dev%% *}
+    dev=${dev##*/}
+
+    if [ -z "$(is_disk $dev)" ] ; then
+      dev=$(partition_to_disk $dev)
+    fi
+  fi
+
+  echo "device = $dev" >&2
+
+  echo $dev
+}
+
+
 target=$(uname --hardware-platform)
 
 if [ -z "$target" ] ; then
@@ -39,19 +122,30 @@ fi
 err=0
 if [ -x /usr/sbin/grub2-install ] ; then
   if [ "$needs_installdevice" = 1 ] ; then
+    has_device=
     if [ -r /etc/default/grub_installdevice ] ; then
       while read device ; do
         # ignore everything that doesn't look like a path
         [ "${device::1}" != "/" ] && continue
         if [ -b "$device" -o -f "$device" ] ; then
+          has_device=1
           ( set -x ; /usr/sbin/grub2-install $trusted --target="$target" --force --skip-fs-probe "$device" ) || err=1
         else
           echo "$device: not a block device"
           err=1
         fi
       done </etc/default/grub_installdevice
-    else
-      echo "/etc/default/grub_installdevice: permission denied"
+    fi
+    if [ -z "$has_device" ] ; then
+      device=$(disk_device)
+      if [ "$device" ] ; then
+        device="/dev/$device"
+        has_device=1
+        ( set -x ; /usr/sbin/grub2-install $trusted --target="$target" --force --skip-fs-probe "$device" ) || err=1
+      fi
+    fi
+    if [ -z "$has_device" ] ; then
+      echo "no grub2 install device found"
       err=1
     fi
   else

--- a/pbl
+++ b/pbl
@@ -42,6 +42,7 @@ my $exit_code = 0;
 my @todo;
 
 my $opt_logfile = "/var/log/pbl.log";
+my $opt_force = 0;
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -59,6 +60,7 @@ Options:
     --install               Install boot loader.
     --config                Create boot loader config.
     --show                  Print current boot loader name.
+    --force                 Work even while YaST is doing an installation.
     --default ENTRY         Set default boot entry to ENTRY.
     --add-option OPTION     Add OPTION to default boot options.
     --del-option OPTION     Delete OPTION from default boot options.
@@ -257,6 +259,7 @@ if($program eq 'pbl') {
     'install'      => sub { push @todo, [ 'install' ] },
     'config'       => sub { push @todo, [ 'config' ] },
     'show'         => sub { print "$loader\n"; exit 0 },
+    'force'        => \$opt_force,
     'default=s'    => sub { push @todo, [ 'default', $_[1] ] },
     'add-option=s' => sub { push @todo, [ 'add-option', $_[1] ] },
     'del-option=s' => sub { push @todo, [ 'del-option', $_[1] ] },
@@ -271,6 +274,8 @@ log_msg(1, join(' ', ($0, @ARGV)));
 log_msg(1, "bootloader = $loader");
 
 exit 0 if !$loader;
+
+delete $ENV{YAST_IS_RUNNING} if $opt_force;
 
 my $lang = $ENV{SYS__LANGUAGE__RC_LANG};
 if(defined $lang) {


### PR DESCRIPTION
In case /etc/default/grub_installdevice is missing or does not contain
devices, install grub2 on the disk the root partition is on.