### PR TITLE
fix device name check (bsc #1033634)

### DIFF
--- a/src/Core/GRUB2.pm
+++ b/src/Core/GRUB2.pm
@@ -126,7 +126,8 @@ sub GetDeviceMap {
             }
         }
 
-        my $sys_dev = $kern_dev;
+        # the following check will not work unless plain kernel device names are used
+        my $sys_dev = $self->GetKernelDevice($kern_dev);
         $sys_dev =~ s#^/dev/##;
         $sys_dev =~ s#/#!#g;
         $sys_dev = "/sys/block/$sys_dev";


### PR DESCRIPTION
The check intends to distinguish between (full) devices and partitions. It will only work if kernel device names are used.