### PR TITLE
Avoid undefined var warning

### DIFF
--- a/src/Tools.pm
+++ b/src/Tools.pm
@@ -596,7 +596,7 @@ sub ReadRAID1Arrays {
 
     $lib_ref->{tools}{mdadm} = $mdadm = AddPathToExecutable("mdadm");
 
-    if (-e $mdadm) {
+    if ($mdadm && -e $mdadm) {
       open (MD, "$mdadm --detail --verbose --scan 2>/dev/null |");
     }
     else {


### PR DESCRIPTION
if mdadm is not installed, a warning was displayed:
`Use of uninitialized value $mdadm in -e at /usr/lib/perl5/vendor_perl/5.26.1/Bootloader/Tools.pm line 599.`