### PR TITLE
add --get-option to pbl (bsc #1033776, bsc #1050349)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,14 @@ install: check
 	@install -m 755 grub2/config $(DESTDIR)/usr/lib/bootloader/grub2
 	@install -m 755 grub2/add-option $(DESTDIR)/usr/lib/bootloader/grub2
 	@install -m 755 grub2/del-option $(DESTDIR)/usr/lib/bootloader/grub2
+	@install -m 755 grub2/get-option $(DESTDIR)/usr/lib/bootloader/grub2
 
 	@install -d -m 755 $(DESTDIR)/usr/lib/bootloader/grub2-efi
 	@install -m 755 grub2-efi/install $(DESTDIR)/usr/lib/bootloader/grub2-efi
 	@install -m 755 grub2/config $(DESTDIR)/usr/lib/bootloader/grub2-efi
 	@install -m 755 grub2/add-option $(DESTDIR)/usr/lib/bootloader/grub2-efi
-	@install -m 755 grub2/del-option $(DESTDIR)/usr/lib/bootloader/grub2
+	@install -m 755 grub2/del-option $(DESTDIR)/usr/lib/bootloader/grub2-efi
+	@install -m 755 grub2/get-option $(DESTDIR)/usr/lib/bootloader/grub2-efi
 
 	@install -d -m 755 $(DESTDIR)/usr/lib/bootloader/u-boot
 	@install -m 755 u-boot/config $(DESTDIR)/usr/lib/bootloader/u-boot

--- a/grub2/get-option
+++ b/grub2/get-option
@@ -1,0 +1,53 @@
+#! /usr/bin/perl
+
+# usage: get-option OPTION
+#
+# Read boot option.
+#
+# OPTION is either of the form 'key=value' or 'key="value"' or just 'key'.
+#
+# The option value is written into the file passed via 'PBL_RESULT' environment var.
+# Either 'option=value', or 'option', or nothing is returned.
+
+use strict;
+
+my $file = "/etc/default/grub";
+
+my $opt = shift;
+
+my $opt_name = $opt;
+
+if($opt_name =~ s/=("?).*//) {
+  $opt =~ s/"/\\"/g;
+}
+
+exit 1 if $opt_name eq "";
+
+open my $f, $file or die "$file: $!\n";
+my @lines = (<$f>);
+close $f;
+
+my $option;
+
+for (@lines) {
+  if(/^(GRUB_CMDLINE_LINUX_DEFAULT)=(.*)/) {
+    my $val = $2;
+
+    $val =~ s/(^"\s*|\s*"\s*$)//g;
+
+    if(
+      $val =~ /(^|\s)($opt=(\\"[^"]*\\"\s*))/ ||
+      $val =~ /(^|\s)($opt((\s|$)|(=\S*\s*)))/
+    ) {
+      $option = $2;
+      $option =~ s/^\s+|\s+$//g;
+    }
+  }
+}
+
+if($option && open my $f, ">", $ENV{PBL_RESULT}) {
+  print $f $option;
+  close $f;
+}
+
+exit 0;

--- a/pbl
+++ b/pbl
@@ -18,6 +18,7 @@
 use strict;
 use POSIX qw ( strftime uname );
 
+use File::Temp;
 use Getopt::Long;
 use Data::Dumper;
 $Data::Dumper::Sortkeys = 1;
@@ -61,6 +62,7 @@ Options:
     --default ENTRY         Set default boot entry to ENTRY.
     --add-option OPTION     Add OPTION to default boot options.
     --del-option OPTION     Delete OPTION from default boot options.
+    --get-option OPTION     Get OPTION from default boot options.
     --log LOGFILE           Log messages to LOGFILE (default: /var/log/pbl.log)
     --version               Show pbl version.
     --help                  Write this help text.
@@ -166,12 +168,23 @@ sub log_msg
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# exit_code = run_command(args)
+#
+# Run external command. All output is logged.
+#
+# The external command may put anything into the (temporary) file passed via
+# 'PBL_RESULT' environment variable. The content of that file is read and
+# printed to STDOUT.
+#
 sub run_command
 {
   my $ret;
   my $output;
 
   my $command = join " ", @_;
+
+  my $result_fh = File::Temp->new(TEMPLATE => 'pbl.XXXXXX');
+  $ENV{PBL_RESULT} = $result_fh->filename;
 
   if(open my $f, "-|") {
     binmode $f, ':utf8';
@@ -189,6 +202,12 @@ sub run_command
 
   if(!$ret) {
     log_msg(1, "'$command' = $ret, output:", $output);
+    local $/;
+    my $result = <$result_fh>;
+    if($result ne "") {
+      print "$result\n";
+      log_msg(1, "result: $result");
+    }
   }
   else {
     log_msg(3, "'$command' failed with exit code $ret, output:", $output);
@@ -241,6 +260,7 @@ if($program eq 'pbl') {
     'default=s'    => sub { push @todo, [ 'default', $_[1] ] },
     'add-option=s' => sub { push @todo, [ 'add-option', $_[1] ] },
     'del-option=s' => sub { push @todo, [ 'del-option', $_[1] ] },
+    'get-option=s' => sub { push @todo, [ 'get-option', $_[1] ] },
     'version'      => sub { print "$VERSION\n"; exit 0 },
     'help'         => sub { pbl_usage 0 },
   ) || pbl_usage 1;


### PR DESCRIPTION
This option returns the boot option as set explicitly in the boot loader
configuration (e.g. /etc/default/grub).

It does not try to provide any auto-generated boot options (like 'root' for
example).

It returns the result in the form 'foo=bar' or 'foo' depending on whether it
was an option with argument or without. It returns nothing if the option was
not set.