### PR TITLE
adjust fallback handling for device translation (bsc #1105380)

### DIFF
--- a/src/Core/GRUB.pm
+++ b/src/Core/GRUB.pm
@@ -592,7 +592,6 @@ sub UnixDev2GrubDev {
         $self->warning("Unknown device/partition, using fallback");
 
         $g_dev = "hd0";
-        $partition = undef;
 
         if (
             $original =~ m#^/dev/(?:vx|das|[ehpsvx])d[a-z]{1,2}(\d+)$# ||


### PR DESCRIPTION
If a device is missing (that is, device.map has incorrect entries)
perl-Bootloader takes a good guess at what was meant.

This fine-tunes the algorithm so it also catches situations where the device
is a raid device.