### PR TITLE
Accept sysconfig values without quotes

### DIFF
--- a/src/Tools.pm
+++ b/src/Tools.pm
@@ -694,7 +694,7 @@ sub GetSysconfigValue
 
   if(open my $fh, Bootloader::Path::Sysconfig()) {
     while(<$fh>) {
-      $val = $1, last if /^\s*$key\s*=\s*"(.*)"\s*$/;
+      $val = $2, last if /^\s*$key\s*=\s*(["']?)(.*?)\1?\s*$/
     }
 
     close $fh;


### PR DESCRIPTION
On Tumbleweed, /etc/sysconfig/bootloader has only
```
LOADER_TYPE=grub2
```

This needed to make the value match non-greedy so that it does
not consume a following quotation-mark `"`

This PR might fix https://bugzilla.opensuse.org/show_bug.cgi?id=1153790