### PR TITLE
Do not warn about missing SECURE_BOOT sysconfig

### DIFF
--- a/src/Tools.pm
+++ b/src/Tools.pm
@@ -669,7 +669,7 @@ See InitLibrary function for example.
 
 sub GetSecureBoot
 {
-  my $val = GetSysconfigValue("SECURE_BOOT");
+  my $val = GetSysconfigValue("SECURE_BOOT") // 0;
 
   $lib_ref->milestone("secureboot = $val") if $lib_ref;
 


### PR DESCRIPTION
Without this patch, systems with a minimalistic /etc/sysconfig/bootloader
triggered such warnings on Leap 15.1:
```
Use of uninitialized value $val in concatenation (.) or string at /usr/lib/perl5
/vendor_perl/5.26.1/Bootloader/Tools.pm line 674.
Use of uninitialized value $val in string eq at /usr/lib/perl5/vendor_perl/5.26.
1/Bootloader/Tools.pm line 676.
```

So on missing value, we default to 0