### PR TITLE
Check tpm.mod in the new grub2 directory (bsc#1174320)

### DIFF
--- a/grub2-efi/install
+++ b/grub2-efi/install
@@ -56,7 +56,7 @@ else
   has_nvram=1
 fi
 
-if [ "$SYS__BOOTLOADER__TRUSTED_BOOT" = yes -a -f "/usr/lib/grub2/$target/tpm.mod" ] ; then
+if [ "$SYS__BOOTLOADER__TRUSTED_BOOT" = yes ] && [ -f "/usr/lib/grub2/$target/tpm.mod" -o -f "/usr/share/grub2/$target/tpm.mod" ] ; then
   append="$append --suse-enable-tpm"
 fi
 


### PR DESCRIPTION
The grub2 module directory has been moved to /usr/share/grub2, so we
have to check tpm.mod there. (bsc#1174320)