### PR TITLE
use shim on aarch64 (jsc#SLE-15823, jsc#SLE-15020)

### DIFF
--- a/grub2-efi/install
+++ b/grub2-efi/install
@@ -64,17 +64,17 @@ if [ "$SYS__BOOTLOADER__UPDATE_NVRAM" = "no" ] ; then
     append="$append --no-nvram"
 fi
 
-if [ "$SYS__BOOTLOADER__SECURE_BOOT" = "yes" -a "$target" != "arm64-efi" ] ; then
-  if [ -x /usr/sbin/shim-install ] ; then
-    ( set -x ; /usr/sbin/shim-install --config-file=/boot/grub2/grub.cfg $append )
-  else
-    echo "shim-install: command not found"
-    exit 1
-  fi
+if [ "$SYS__BOOTLOADER__SECURE_BOOT" = "yes" -a -x /usr/sbin/shim-install ] ; then
+  ( set -x ; /usr/sbin/shim-install --config-file=/boot/grub2/grub.cfg $append )
 elif [ -x /usr/sbin/grub2-install ] ; then
-  # Use '--suse-force-signed' when shim is not used (aarch64 case)
   if [ "$SYS__BOOTLOADER__SECURE_BOOT" = "yes" ] ; then
-     append="$append --suse-force-signed"
+    # Use '--suse-force-signed' when shim is not used (aarch64 case)
+    if [ "$target" = "arm64-efi" ] ; then
+      append="$append --suse-force-signed"
+    else
+      echo "shim-install: command not found"
+      exit 1
+    fi
   fi
   if [ "$has_nvram" = 1 -a "$target" = "arm64-efi" ] ; then
     # some arm firmwares need the fallback even though they have nvram vars (bsc#1167015)


### PR DESCRIPTION
## Task

- https://trello.com/c/E4U5cNa9
- https://jira.suse.com/browse/SLE-15020
- https://jira.suse.com/browse/SLE-15823

Adjust `perl-Bootloder` to use shim on aarch64 - if it is available.

## Notes

If secure boot is enabled but there's no shim it will log an error - except on arm64-efi where `--suse-force-signed` is appended to grub-install.

## Testing

I tested this on current Tumbleweed in qemu; see https://github.com/openSUSE/perl-bootloader/issues/132. sle15-sp3 images don't seem to have shim yet.

## Related

- https://bugzilla.suse.com/show_bug.cgi?id=1136601#c24
- https://github.com/yast/yast-bootloader/pull/632