### PR TITLE
install with --removable if efivars are not writable (bsc#1182749, bsc#1174111, bsc#1184160)

### DIFF
--- a/grub2-efi/install
+++ b/grub2-efi/install
@@ -50,7 +50,7 @@ fi
 no_nvram_opts="--no-nvram --removable"
 has_nvram=0
 append=
-if [ ! -d /sys/firmware/efi/efivars -o ! "$(ls -A /sys/firmware/efi/efivars)" ] ; then
+if [ ! -d /sys/firmware/efi/efivars -o ! -w /sys/firmware/efi/efivars -o ! "$(ls -A /sys/firmware/efi/efivars)" ] ; then
   append="$no_nvram_opts"
 else
   has_nvram=1

--- a/grub2-efi/install
+++ b/grub2-efi/install
@@ -27,8 +27,8 @@ echo "target = $target"
 
 # We install grub2 at the end of the installation, not within (bsc#979145)
 if [ "$YAST_IS_RUNNING" = instsys ]; then
-	echo "Skipping grub2-efi during installation. Will be done at the end"
-	exit 0
+  echo "Skipping grub2-efi during installation. Will be done at the end"
+  exit 0
 fi
 
 # EFI has 2 boot paths. The default is that there is a target file listed in


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1182749
- https://bugzilla.suse.com/show_bug.cgi?id=1174111
- https://bugzilla.suse.com/show_bug.cgi?id=1184160
- https://trello.com/c/SR4I7TEh

On some EFI systems efivars are not writable. In that case, add `--removable` to `grub2-install` so it doesn't try to create an EFI boot entry.