### PR TITLE
report error if config file could not be updated (bsc#1188768)

### DIFF
--- a/grub2/add-option
+++ b/grub2/add-option
@@ -46,9 +46,15 @@ for (@lines) {
 
 exit 0 unless $changed;
 
-open my $f, ">$file.pblnew" or die "$file.pblnew: $!\n";
-print $f @lines;
-close $f;
+my $f;
 
-rename "$file.pblnew", $file;
+if(!(
+  open $f, ">$file.pblnew" and
+  print $f @lines and
+  close $f and
+  rename "$file.pblnew", $file
+)) {
+  unlink "$file.pblnew";
+  die "$file: failed to update config file\n"
+}
 

--- a/grub2/del-option
+++ b/grub2/del-option
@@ -41,9 +41,15 @@ for (@lines) {
 
 exit 0 unless $changed;
 
-open my $f, ">$file.pblnew" or die "$file.pblnew: $!\n";
-print $f @lines;
-close $f;
+my $f;
 
-rename "$file.pblnew", $file;
+if(!(
+  open $f, ">$file.pblnew" and
+  print $f @lines and
+  close $f and
+  rename "$file.pblnew", $file
+)) {
+  unlink "$file.pblnew";
+  die "$file: failed to update config file\n"
+}
 


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1188768

Be sure to catch any error that may happen during config file update. Like out-of-disk-space as reported in the linked bug.