### PR TITLE
grub2/install: reset error code when passing through recover code (bsc#1198197)

### DIFF
--- a/grub2/install
+++ b/grub2/install
@@ -180,6 +180,7 @@ if [ -x /usr/sbin/grub2-install ] ; then
         if [ "$device" ] ; then
           device="/dev/$device"
           has_device=1
+          err=0
           ( set -x ; /usr/sbin/grub2-install $append $trusted --target="$target" --force --skip-fs-probe "$device" ) || err=1
         fi
       fi


### PR DESCRIPTION
The script tries to identify the device, 'fails', sets err=1 and
then goes into an error handler to recover from the situation.
In this case though, irrespective of the result of the error handler,
the final result remained err=1.

Reset err to 0 before attempting to write the config on the
auto-detected device.

https://bugzilla.opensuse.org/show_bug.cgi?id=1198197
