### PR TITLE
fix sysconfig parsing (bsc#1198828)

### DIFF
--- a/pbl
+++ b/pbl
@@ -233,7 +233,7 @@ sub read_sysconfig
       if(/^([A-Z_]+)=(.*?)\s*$/) {
         my $key = $1;
         my $val = $2;
-        $val =~ s/^(["'])(.*)\1$/$2/g;
+        $val =~ s/^(["'])(.*?)\1.*/$2/;
         $ENV{"SYS__\U$file\E__$key"} = $val;
       }
     }


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1198828

If `/etc/sysconfig/language` contains a line like

```
RC_LANG="de_DE.UTF-8" # managed by puppet
```

`pbl` parses this line incorrectly and includes the comment in the locale value, breaking `grub2-mkconfig`.

## Solution

Take care lines with appended comments are parsed correctly. For example

```
FOO="ABC 123"    # a comment
BAR="123 ABC"    # a "comment"
```