### PR TITLE
add basic support for systemd-boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,12 @@ install: check
 	@install -d -m 755 $(DESTDIR)/usr/lib/bootloader/u-boot
 	@install -m 755 u-boot/config $(DESTDIR)/usr/lib/bootloader/u-boot
 
+	@install -d -m 755 $(DESTDIR)/usr/lib/bootloader/systemd-boot
+	@install -m 755 systemd-boot/install $(DESTDIR)/usr/lib/bootloader/systemd-boot
+	@install -m 755 systemd-boot/config $(DESTDIR)/usr/lib/bootloader/systemd-boot
+	@install -m 755 systemd-boot/add-kernel $(DESTDIR)/usr/lib/bootloader/systemd-boot
+	@install -m 755 systemd-boot/remove-kernel $(DESTDIR)/usr/lib/bootloader/systemd-boot
+
 	@install -m 755 pbl $(DESTDIR)/sbin/pbl
 	@perl -pi -e 's/0\.0/$(VERSION)/ if /VERSION = /' $(DESTDIR)/sbin/pbl
 	@ln -snf pbl $(DESTDIR)/sbin/update-bootloader

--- a/pbl
+++ b/pbl
@@ -30,6 +30,7 @@ my $VERSION = "0.0";
 my $pbl_dir = "/usr/lib/bootloader";
 
 sub pbl_usage;
+sub bootloader_entry_usage;
 sub new;
 sub log_msg;
 sub run_command;
@@ -42,7 +43,8 @@ my $exit_code = 0;
 my @todo;
 
 my $opt_logfile = "/var/log/pbl.log";
-
+my @opt_add_kernel;
+my @opt_remove_kernel;
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # pbl_usage($exit_code)
@@ -56,17 +58,39 @@ Usage: pbl [OPTIONS]
 Configure/install boot loader.
 
 Options:
-    --install               Install boot loader.
-    --config                Create boot loader config.
-    --show                  Print current boot loader name.
-    --default ENTRY         Set default boot entry to ENTRY.
-    --add-option OPTION     Add OPTION to default boot options.
-    --del-option OPTION     Delete OPTION from default boot options.
-    --get-option OPTION     Get OPTION from default boot options.
-    --log LOGFILE           Log messages to LOGFILE (default: /var/log/pbl.log)
-    --version               Show pbl version.
-    --help                  Write this help text.
+    --install                   Install boot loader.
+    --config                    Create boot loader config.
+    --show                      Print current boot loader name.
+    --default ENTRY             Set default boot entry to ENTRY.
+    --add-option OPTION         Add OPTION to default boot options (grub2).
+    --del-option OPTION         Delete OPTION from default boot options (grub2).
+    --get-option OPTION         Get OPTION from default boot options (grub2).
+    --add-kernel VERSION FILE [INITRD]
+                                Add kernel FILE with version VERSION. Optionally add initrd file INITRD
+                                explicitly (systemd-boot).
+    --remove-kernel VERSION [FILE [INITRD]]
+                                Remove kernel with version VERSION. Optionally specify kernel and initrd
+                                explicitly (systemd-boot).
+    --log LOGFILE               Log messages to LOGFILE (default: /var/log/pbl.log)
+    --version                   Show pbl version.
+    --help                      Write this help text.
 
+= = = = = = = =
+
+  exit shift;
+}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# bootloader_entry_usage($exit_code)
+#
+# Print help text and exit.
+#
+sub bootloader_entry_usage
+{
+  print <<"= = = = = = = =";
+Usage: bootloader_entry add|remove kernel-flavor kernel-version kernel-image initrd-file
+Add or remove kernel images to boot config.
 = = = = = = = =
 
   exit shift;
@@ -253,17 +277,31 @@ $loader = $ENV{SYS__BOOTLOADER__LOADER_TYPE};
 
 if($program eq 'pbl') {
   GetOptions(
-    'log=s'        => \$opt_logfile,
-    'install'      => sub { push @todo, [ 'install' ] },
-    'config'       => sub { push @todo, [ 'config' ] },
-    'show'         => sub { print "$loader\n"; exit 0 },
-    'default=s'    => sub { push @todo, [ 'default', $_[1] ] },
-    'add-option=s' => sub { push @todo, [ 'add-option', $_[1] ] },
-    'del-option=s' => sub { push @todo, [ 'del-option', $_[1] ] },
-    'get-option=s' => sub { push @todo, [ 'get-option', $_[1] ] },
-    'version'      => sub { print "$VERSION\n"; exit 0 },
-    'help'         => sub { pbl_usage 0 },
+    'log=s'                => \$opt_logfile,
+    'install'              => sub { push @todo, [ 'install' ] },
+    'config'               => sub { push @todo, [ 'config' ] },
+    'show'                 => sub { print "$loader\n"; exit 0 },
+    'default=s'            => sub { push @todo, [ 'default', $_[1] ] },
+    'add-option=s'         => sub { push @todo, [ 'add-option', $_[1] ] },
+    'del-option=s'         => sub { push @todo, [ 'del-option', $_[1] ] },
+    'get-option=s'         => sub { push @todo, [ 'get-option', $_[1] ] },
+    'add-kernel=s{2,3}'    => \@opt_add_kernel,
+    'remove-kernel=s{1,3}' => \@opt_remove_kernel,
+    'version'              => sub { print "$VERSION\n"; exit 0 },
+    'help'                 => sub { pbl_usage 0 },
   ) || pbl_usage 1;
+
+  push @todo, [ "add-kernel", @opt_add_kernel ] if @opt_add_kernel;
+  push @todo, [ "remove-kernel", @opt_remove_kernel ] if @opt_remove_kernel;
+}
+
+if($program eq 'bootloader_entry') {
+  if($ARGV[0] =~ /^(add|remove)$/ && @ARGV == 5) {
+    push @todo, [ "$ARGV[0]-kernel", @ARGV[2..4] ]
+  }
+  else {
+    bootloader_entry_usage 1;
+  }
 }
 
 log_msg(1, join(' ', ($0, @ARGV)));
@@ -289,12 +327,14 @@ if($program ne 'pbl') {
 if(-d "$pbl_dir/$loader") {
   for (@todo) {
     my @cmd = @{$_};
+    my $opt = $cmd[0];
     $cmd[0] = "$pbl_dir/$loader/$cmd[0]";
     if(-x $cmd[0]) {
       $exit_code = run_command(@cmd) || $exit_code;
     }
     else {
       log_msg(1, "$cmd[0] skipped");
+      print "Option --$opt not available for $loader.\n";
     }
   }
 }
@@ -305,4 +345,3 @@ else {
 }
 
 exit $exit_code;
-

--- a/systemd-boot/add-kernel
+++ b/systemd-boot/add-kernel
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+# Settings from /etc/sysconfig/filename are available as environment vars
+# with the name 'SYS__FILENAME__KEY' (filename converted to upper case).
+#
+# Not all files are parsed, current list is:
+#   bootloader, language
+#
+
+# usage: add-kernel KERNEL-VERSION KERNEL-FILE [INITRD-FILE]
+#
+# Add kernel/initrd to boot config.
+
+err=0
+if [ -x /usr/bin/kernel-install ] ; then
+  ( set -x ; kernel-install add $* ) || err=1
+else
+  echo "kernel-install: command not found"
+  err=1
+fi
+
+exit $err

--- a/systemd-boot/config
+++ b/systemd-boot/config
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+# Settings from /etc/sysconfig/filename are available as environment vars
+# with the name 'SYS__FILENAME__KEY' (filename converted to upper case).
+#
+# Not all files are parsed, current list is:
+#   bootloader, language
+#
+
+echo "nothing to do, really"

--- a/systemd-boot/install
+++ b/systemd-boot/install
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+# Settings from /etc/sysconfig/filename are available as environment vars
+# with the name 'SYS__FILENAME__KEY' (filename converted to upper case).
+#
+# Not all files are parsed, current list is:
+#   bootloader, language
+#
+
+err=0
+if [ -x /usr/bin/bootctl ] ; then
+  ( set -x ; bootctl --make-machine-id-directory=yes install ) || err=1
+else
+  echo "bootctl: command not found"
+  err=1
+fi
+
+exit $err

--- a/systemd-boot/remove-kernel
+++ b/systemd-boot/remove-kernel
@@ -1,0 +1,22 @@
+#! /bin/bash
+
+# Settings from /etc/sysconfig/filename are available as environment vars
+# with the name 'SYS__FILENAME__KEY' (filename converted to upper case).
+#
+# Not all files are parsed, current list is:
+#   bootloader, language
+#
+
+# usage: remove-kernel KERNEL-VERSION [KERNEL-FILE [INITRD-FILE]]
+#
+# Remove kernel/initrd from boot config.
+
+err=0
+if [ -x /usr/bin/kernel-install ] ; then
+  ( set -x ; kernel-install remove $1 ) || err=1
+else
+  echo "kernel-install: command not found"
+  err=1
+fi
+
+exit $err


### PR DESCRIPTION
## Task

Add basic systemd-boot support.

## Implementation

systemd-boot has its own tool set; this is just a light wrapper around `bootctl install` and `kernel-install` to go along with existing bootloader tooling in Tumbleweed.