### PR TITLE
use signed grub EFI binary when updating grub in default EFI location (bsc#1210799)

### DIFF
--- a/grub2-efi/install
+++ b/grub2-efi/install
@@ -27,6 +27,7 @@ check_update_default ()
 
   update_default=0
 
+  # install/update default location if it is 'our' file
   if [ -n "$ca_string" -a -f $efi_default_file ] ; then
     grep -q "$ca_string" $efi_default_file && update_default=1
   fi
@@ -59,8 +60,6 @@ check_update_default
 
 target="$target-efi"
 
-echo "target = $target, update default location = $update_default"
-
 # We install grub2 at the end of the installation, not within (bsc#979145)
 if [ "$YAST_IS_RUNNING" = instsys ]; then
   echo "Skipping grub2-efi during installation. Will be done at the end"
@@ -92,14 +91,20 @@ if [ ! -d /sys/firmware/efi/efivars -o ! -w /sys/firmware/efi/efivars -o ! "$(ls
   update_default=0
 else
   has_nvram=1
+  # some arm firmwares need the fallback even though they have nvram vars (bsc#1167015)
+  if [ "$target" = "arm64-efi" ] ; then
+    update_default=1
+  fi
 fi
+
+echo "target = $target, update default location = $update_default"
 
 if [ "$SYS__BOOTLOADER__TRUSTED_BOOT" = yes ] && [ -f "/usr/lib/grub2/$target/tpm.mod" -o -f "/usr/share/grub2/$target/tpm.mod" ] ; then
   append="$append --suse-enable-tpm"
 fi
 
 if [ "$SYS__BOOTLOADER__UPDATE_NVRAM" = "no" ] ; then
-    append="$append --no-nvram"
+  append="$append --no-nvram"
 fi
 
 if [ "$SYS__BOOTLOADER__SECURE_BOOT" = "yes" -a -x /usr/sbin/shim-install ] ; then
@@ -114,13 +119,15 @@ elif [ -x /usr/sbin/grub2-install ] ; then
       exit 1
     fi
   fi
-  if [ "$has_nvram" = 1 -a "$target" = "arm64-efi" ] ; then
-    # some arm firmwares need the fallback even though they have nvram vars (bsc#1167015)
-    ( set -x ; /usr/sbin/grub2-install --target="$target" $append $no_nvram_opts )
-  fi
   ( set -x ; /usr/sbin/grub2-install --target="$target" $append )
   if [ "$update_default" = 1 ] ; then
-    ( set -x ; /usr/sbin/grub2-install --target="$target" $append $no_nvram_opts )
+    if [ -x /usr/sbin/shim-install ] ; then
+      # update shim to fallback location given it is used most often
+      ( set -x ; /usr/sbin/shim-install --config-file=/boot/grub2/grub.cfg --removable )
+    else
+      # fallback to signed grub so that check_update_default can still work
+      ( set -x ; cp /usr/share/grub2/x86_64-efi/grub.efi /boot/efi/EFI/boot/$efi_default )
+    fi
   fi
 else
   echo "grub2-install: command not found"


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/perl-bootloader/pull/149 to SLE15.

## Original problem

- https://bugzilla.suse.com/show_bug.cgi?id=1210799

The previous patch may install an unsigned `grub.efi`, causing follow-up updates fail to identify `grub.efi` as belonging to SUSE.

## Solution

grub2-install will create an unsigned grub2; use shim if available or copy the pre-signed grub.efi binary instead.
This is case 3  in **Discussion** below.

## Discussion

Note: default location is only updated if the current default EFI loader is signed by SUSE.

1. shim + secure boot
    - SUSE location: shim-install
    - default location: shim-install --removable
2. shim, no secure boot
    - SUSE location: grub-install
    - default location: shim-install --removable
3. no shim
    - SUSE location: grub-install
    - default location: copy `grub.efi` to `/efi/boot/bootARCH.efi`
