### PR TITLE
move kexec-bootloader from kexec-tools to perl-Bootloader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,8 @@ install: check
 	@install -d -m 755 $(DESTDIR)/usr/share/man/man8
 	@install -D -m 644 pbl.logrotate $(DESTDIR)$(ETCDIR)/logrotate.d/pbl
 
+	@install -D -m 755 kexec-bootloader $(DESTDIR)$(SBINDIR)/kexec-bootloader
+
 archive: changelog
 	mkdir -p package
 	git archive --prefix=$(PREFIX)/ $(BRANCH) > package/$(PREFIX).tar

--- a/obs/perl-Bootloader.spec
+++ b/obs/perl-Bootloader.spec
@@ -25,11 +25,12 @@
 %{!?_distconfdir:%global _distconfdir /etc}
 
 Name:           perl-Bootloader
-Version:        1.0
+Version:        0.0
 Release:        0
 Requires:       coreutils
 Requires:       perl-base = %{perl_version}
 Obsoletes:      perl-Bootloader-YAML < %{version}
+Conflicts:      kexec-tools < 2.0.26.0
 Summary:        Tool for boot loader configuration
 License:        GPL-2.0-or-later
 Group:          System/Boot
@@ -54,6 +55,7 @@ make doc
 install -D -m 644 pbl.8 %{buildroot}%{_mandir}/man8/pbl.8
 install -D -m 644 bootloader_entry.8 %{buildroot}%{_mandir}/man8/bootloader_entry.8
 install -D -m 644 update-bootloader.8 %{buildroot}%{_mandir}/man8/update-bootloader.8
+install -D -m 644 kexec-bootloader.8 %{buildroot}%{_mandir}/man8/kexec-bootloader.8
 mkdir -p %{buildroot}/var/log
 touch %{buildroot}/var/log/pbl.log
 
@@ -68,6 +70,7 @@ chmod 600 /var/log/pbl.log
 %doc boot.readme
 %{sbindir}/update-bootloader
 %{sbindir}/pbl
+%{sbindir}/kexec-bootloader
 /usr/lib/bootloader
 %if "%{_distconfdir}" == "/etc"
 %config(noreplace) %{_distconfdir}/logrotate.d/pbl


### PR DESCRIPTION
## Task

`kexec-bootloader` has so far been provided as part of the kexec-tools package. But it is a SUSE specific script that is not part of kexec-tools upstream.

Since it depends on perl-Bootloader and has no own source repo anyway, move it to perl-Bootloader.