### PR TITLE
bootloader_entry script can have an optional 'force-default' argument (bsc#1215064)

### DIFF
--- a/pbl
+++ b/pbl
@@ -300,7 +300,8 @@ if($program eq 'pbl') {
 }
 
 if($program eq 'bootloader_entry') {
-  if($ARGV[0] =~ /^(add|remove)$/ && @ARGV == 5) {
+  # there might be an optional 6th argument 'force-default'
+  if($ARGV[0] =~ /^(add|remove)$/ && @ARGV >= 5) {
     push @todo, [ "$ARGV[0]-kernel", @ARGV[2..4] ]
   }
   else {


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1215064

Updating the kernel-rt package leads to an error running `bootloader_entry`.

`pbl` had a too strict argument checking, not expecting the optional `force-default` argument.