### PR TITLE
bootloader_entry script can have an optional 'force-default' argument (bsc#1215064)

### DIFF
--- a/pbl
+++ b/pbl
@@ -298,7 +298,8 @@ if($program eq 'pbl') {
 }
 
 if($program eq 'bootloader_entry') {
-  if($ARGV[0] =~ /^(add|remove)$/ && @ARGV == 5) {
+  # there might be an optional 6th argument 'force-default'
+  if($ARGV[0] =~ /^(add|remove)$/ && @ARGV >= 5) {
     push @todo, [ "$ARGV[0]-kernel", @ARGV[2..4] ]
   }
   else {

--- a/pbl
+++ b/pbl
@@ -337,7 +337,7 @@ if(-d "$pbl_dir/$loader" || $program eq "pbl") {
     }
     else {
       log_msg(1, "$cmd[0] skipped");
-      print "Option --$opt not available for $loader.\n";
+      print "Option --$opt not available for $loader.\n" if $program eq "pbl";
     }
   }
 }


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/perl-bootloader/pull/156 to SLE15.

## Original problem

- https://bugzilla.suse.com/show_bug.cgi?id=1215064

Updating the kernel-rt package leads to an error running `bootloader_entry`.

`pbl` had a too strict argument checking, not expecting the optional `force-default` argument.