### PR TITLE
support old grub versions (<= 2.02) that used /usr/lib (bsc#1218842)

### DIFF
--- a/grub2-efi/install
+++ b/grub2-efi/install
@@ -139,7 +139,10 @@ elif [ -x /usr/sbin/grub2-install ] ; then
       ( set -x ; /usr/sbin/shim-install --config-file=/boot/grub2/grub.cfg --removable )
     else
       # fallback to signed grub so that check_update_default can still work
-      ( set -x ; cp /usr/share/grub2/$target/grub.efi /boot/efi/EFI/boot/$efi_default )
+      # older grub (<= 2.02) uses /usr/lib
+      grub_dir="/usr/share/grub2/$target"
+      [ -d "$grub_dir" ] || grub_dir="/usr/lib/grub2/$target"
+      ( set -x ; cp "$grub_dir/grub.efi" "/boot/efi/EFI/boot/$efi_default" )
     fi
   fi
 else

--- a/grub2-efi/install
+++ b/grub2-efi/install
@@ -142,6 +142,8 @@ elif [ -x /usr/sbin/grub2-install ] ; then
       # older grub (<= 2.02) uses /usr/lib
       grub_dir="/usr/share/grub2/$target"
       [ -d "$grub_dir" ] || grub_dir="/usr/lib/grub2/$target"
+      # directory may not yet exist in some workflows
+      mkdir -p "/boot/efi/EFI/boot"
       ( set -x ; cp "$grub_dir/grub.efi" "/boot/efi/EFI/boot/$efi_default" )
     fi
   fi


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1218842

On UEFI platforms with secure boot off and no shim installed, `pbl` will copy `grub.efi` itself.

Old grub package versions (up to 2.02) used `/usr/lib/grub2`. Current grub packages use `/usr/share/grub2`.

With this patch, support both locations.