### PR TITLE
log grub2-install errors correctly (bsc#1221470)

### DIFF
--- a/grub2/install
+++ b/grub2/install
@@ -203,7 +203,7 @@ if [ -x /usr/sbin/grub2-install ] ; then
       err=1
     fi
   else
-    ( set -x ; /usr/sbin/grub2-install $append $trusted --target="$target" )
+    ( set -x ; /usr/sbin/grub2-install $append $trusted --target="$target" ) || err=1
   fi
 else
   echo "grub2-install: command not found"


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1221470

Log `grub2-install` errors also on architectures that don't use `/etc/default/grub_installdevice` (E.g. UEFI systems or S390X).

## See also

The same for Tumbleweed (shell script based perl-Bootloader):

- https://github.com/openSUSE/perl-bootloader/pull/165

For SLE15-SP4, SLE15-SP5:

- https://github.com/openSUSE/perl-bootloader/pull/166