### PR TITLE
rename package perl-Bootloader to update-bootloader (bsc#1214361)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GIT2LOG := $(shell if [ -x ./git2log ] ; then echo ./git2log --update ; else echo true ; fi)
 GITDEPS := $(shell [ -d .git ] && echo .git/HEAD .git/refs/heads .git/refs/tags)
 VERSION := $(shell $(GIT2LOG) --version VERSION ; cat VERSION)
-PREFIX  := perl-Bootloader-$(VERSION)
+PREFIX  := update-bootloader-$(VERSION)
 
 SBINDIR ?= /usr/sbin
 ETCDIR  ?= /usr/etc
@@ -20,7 +20,7 @@ install:
 	@perl -pi -e 's/0\.0/$(VERSION)/ if /VERSION ?=/' $(DESTDIR)$(SBINDIR)/pbl
 	@ln -snf pbl $(DESTDIR)$(SBINDIR)/update-bootloader
 	@ln -rsnf $(DESTDIR)$(SBINDIR)/pbl $(DESTDIR)/usr/lib/bootloader/bootloader_entry
-	@install -D -m 644 boot.readme $(DESTDIR)/usr/share/doc/packages/perl-Bootloader/boot.readme
+	@install -D -m 644 boot.readme $(DESTDIR)/usr/share/doc/packages/update-bootloader/boot.readme
 	@install -D -m 644 pbl.logrotate $(DESTDIR)$(ETCDIR)/logrotate.d/pbl
 	@install -D -m 755 kexec-bootloader $(DESTDIR)$(SBINDIR)/kexec-bootloader
 	@install -d -m 755 $(DESTDIR)/usr/share/man/man8

--- a/obs/update-bootloader.spec
+++ b/obs/update-bootloader.spec
@@ -1,7 +1,7 @@
 #
-# spec file for package perl-Bootloader
+# spec file for package update-bootloader
 #
-# Copyright (c) 2023 SUSE LLC
+# Copyright (c) 2024 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -24,11 +24,13 @@
 
 %{!?_distconfdir:%global _distconfdir /etc}
 
-Name:           perl-Bootloader
+Name:           update-bootloader
 Version:        0.0
 Release:        0
 Requires:       coreutils
 Obsoletes:      perl-Bootloader-YAML < %{version}
+Obsoletes:      perl-Bootloader < %{version}-%{release}
+Provides:       perl-Bootloader = %{version}-%{release}
 Conflicts:      kexec-tools < 2.0.26.0
 Summary:        Tool for boot loader configuration
 License:        GPL-2.0-or-later


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1214361

Rename `perl-Bootloader` package to `update-bootloader`.