### PR TITLE
Fixing some features for BLS

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,1 @@
+((sh-mode . ((sh-basic-offset . 2))))

--- a/grub2-bls/config
+++ b/grub2-bls/config
@@ -1,1 +1,1 @@
-../grub2-efi/config
+../systemd-boot/config

--- a/grub2-bls/default
+++ b/grub2-bls/default
@@ -1,1 +1,1 @@
-../grub2-efi/default
+../systemd-boot/default

--- a/grub2-bls/install
+++ b/grub2-bls/install
@@ -1,1 +1,1 @@
-../grub2-efi/install
+../systemd-boot/install

--- a/systemd-boot/default
+++ b/systemd-boot/default
@@ -1,0 +1,18 @@
+#! /usr/bin/sh
+
+# Settings from /etc/sysconfig/filename are available as environment vars
+# with the name 'SYS__FILENAME__KEY' (filename converted to upper case).
+#
+# Not all files are parsed, current list is:
+#   bootloader, language
+#
+
+err=0
+if [ -x /usr/bin/bootctl ] ; then
+  ( set -x ; bootctl set-default "$1" ) || err=1
+else
+  echo "bootctl: command not found"
+  err=1
+fi
+
+exit $err

--- a/systemd-boot/default-settings
+++ b/systemd-boot/default-settings
@@ -10,31 +10,20 @@
 # include common functions
 . "$PBL_INCLUDE/library"
 
-target=$(uname -m)
-
-case "$target" in
-  x86_64|i?86)
-    image=vmlinuz ;;
-  ppc*)
-    image=vmlinux ;;
-  s390*)
-    image=image ;;
-  armv*)
-    image=zImage ;;
-  aarch64|riscv64)
-    image=Image ;;
-  *)
-    echo "Architecture $target not supported."
-esac
-
 lib_get_cmdline_bls
 
-kernel=$(readlink -f "/boot/$image")
-initrd=$(readlink -f /boot/initrd)
-append=\"$(lib_shellquote "$cmdline")\"
+err=0
+if [ -x /usr/bin/bootctl ]; then
+  kernel=$(bootctl status | grep linux: | cut -d':' -f2 | tr -d ' ')
+  initrd=$(bootctl status | grep initrd: | cut -d':' -f2 | tr -d ' ')
+  append=\"$(lib_shellquote "$cmdline")\"
 
-echo "kernel=$kernel" > "$PBL_RESULT"
-echo "initrd=$initrd" >> "$PBL_RESULT"
-echo -n "append=$append" >> "$PBL_RESULT"
+  echo "kernel=$kernel" > "$PBL_RESULT"
+  echo "initrd=$initrd" >> "$PBL_RESULT"
+  echo -n "append=$append" >> "$PBL_RESULT"
+else
+  echo "bootctl: command not found"
+  err=1
+fi
 
-exit 0
+exit $err

--- a/systemd-boot/install
+++ b/systemd-boot/install
@@ -8,10 +8,10 @@
 #
 
 err=0
-if [ -x /usr/bin/bootctl ] ; then
-  ( set -x ; bootctl --make-machine-id-directory=yes install ) || err=1
+if [ -x /usr/bin/sdbootutil ] ; then
+  sdbootutil install || err=1
 else
-  echo "bootctl: command not found"
+  echo "sdbootutil: command not found"
   err=1
 fi
 


### PR DESCRIPTION
Some features in BLS (systemd-boot and the new grub2bls subpackage) requires a different approach

- [X] (sdb, g2) default-settings. /boot/{vmlinuz,initrd} are not present
- [X] (sdb, g2) install can break the shim
- [X] (sdb) install should add the shim and systemd boot EFI to grub.efi
- [X] (sdb, g2) no configuration files
- [X] (sdb, g2) select default boot entry
