### PR TITLE
fix handling of missing grub_installdevice on powerpc (bsc#1230070)

### DIFF
--- a/grub2/install
+++ b/grub2/install
@@ -16,6 +16,24 @@
 #
 
 
+# Usage: prep_partition(disk)
+#
+# Find a PReP partition on a disk
+# Partition and disk name are without leading '/dev/'.
+#
+# Return empty string is there is no PReP partition.
+#
+prep_partition ()
+{
+  prep_part=$(/usr/sbin/fdisk -l -o "Device,Type" "/dev/$1" | grep -m1 PReP | cut -d ' ' -f 1)
+  prep_part="${prep_part#/dev/}"
+
+  echo "prep_partition($1) = $prep_part" >&2
+
+  echo "$prep_part"
+}
+
+
 # Usage: partition_to_disk(partition)
 #
 # Find disk device name for a partition.
@@ -187,6 +205,9 @@ if [ -x /usr/sbin/grub2-install ] ; then
       if [ "$target" = "i386-pc" -o "$target" = "powerpc-ieee1275" ] ; then
         echo "determining suitable boot device"
         device=$(disk_device /boot)
+        if [ -n "$device" -a "$target" = "powerpc-ieee1275" ] ; then
+          device=$(prep_partition $device)
+        fi
         if [ "$device" ] ; then
           device="/dev/$device"
           has_device=1

--- a/obs/update-bootloader.spec
+++ b/obs/update-bootloader.spec
@@ -28,6 +28,7 @@ Name:           update-bootloader
 Version:        0.0
 Release:        0
 Requires:       coreutils
+Requires:       util-linux
 Obsoletes:      perl-Bootloader-YAML < %{version}
 Obsoletes:      perl-Bootloader < %{version}-%{release}
 Provides:       perl-Bootloader = %{version}-%{release}


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1230070

## See also

This replaces

- https://github.com/openSUSE/perl-bootloader/pull/174

## Notes

This pull request is blocked until the update-bootloader renaming has been accepted into Factory.

The test case still needs to be adjusted; this will be done when this pr is merged.