### PR TITLE
support both update-bootloader and perl-Bootloader as package name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
+PACKAGE_NAME := $(shell if [ -f PACKAGE_NAME ] ; then cat PACKAGE_NAME ; else echo update-bootloader ; fi)
 GIT2LOG := $(shell if [ -x ./git2log ] ; then echo ./git2log --update ; else echo true ; fi)
 GITDEPS := $(shell [ -d .git ] && echo .git/HEAD .git/refs/heads .git/refs/tags)
 VERSION := $(shell $(GIT2LOG) --version VERSION ; cat VERSION)
-PREFIX  := update-bootloader-$(VERSION)
+PREFIX  := $(PACKAGE_NAME)-$(VERSION)
 
 SBINDIR ?= /usr/sbin
 ETCDIR  ?= /usr/etc
@@ -20,7 +21,7 @@ install:
 	@perl -pi -e 's/0\.0/$(VERSION)/ if /VERSION ?=/' $(DESTDIR)$(SBINDIR)/pbl
 	@ln -snf pbl $(DESTDIR)$(SBINDIR)/update-bootloader
 	@ln -rsnf $(DESTDIR)$(SBINDIR)/pbl $(DESTDIR)/usr/lib/bootloader/bootloader_entry
-	@install -D -m 644 boot.readme $(DESTDIR)/usr/share/doc/packages/update-bootloader/boot.readme
+	@install -D -m 644 boot.readme $(DESTDIR)/usr/share/doc/packages/$(PACKAGE_NAME)/boot.readme
 	@install -D -m 644 pbl.logrotate $(DESTDIR)$(ETCDIR)/logrotate.d/pbl
 	@install -D -m 755 kexec-bootloader $(DESTDIR)$(SBINDIR)/kexec-bootloader
 	@install -d -m 755 $(DESTDIR)/usr/share/man/man8

--- a/obs/perl-Bootloader.spec
+++ b/obs/perl-Bootloader.spec
@@ -1,0 +1,80 @@
+#
+# spec file for package perl-Bootloader
+#
+# Copyright (c) 2024 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+%if %{suse_version} > 1550
+%define sbindir %{_sbindir}
+%else
+%define sbindir /sbin
+%endif
+
+%{!?_distconfdir:%global _distconfdir /etc}
+
+Name:           perl-Bootloader
+Version:        0.0
+Release:        0
+Requires:       coreutils
+Requires:       util-linux
+Obsoletes:      perl-Bootloader-YAML < %{version}
+Conflicts:      kexec-tools < 2.0.26.0
+Summary:        Tool for boot loader configuration
+License:        GPL-2.0-or-later
+Group:          System/Boot
+URL:            https://github.com/openSUSE/perl-bootloader
+Source:         %{name}-%{version}.tar.xz
+BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+BuildRequires:  rubygem(asciidoctor)
+
+%description
+Shell script wrapper for configuring various boot loaders.
+
+%prep
+%setup -q
+
+%build
+
+%install
+make install DESTDIR=%{buildroot} SBINDIR=%{sbindir} ETCDIR=%{_distconfdir}
+make doc
+install -D -m 644 pbl.8 %{buildroot}%{_mandir}/man8/pbl.8
+install -D -m 644 bootloader_entry.8 %{buildroot}%{_mandir}/man8/bootloader_entry.8
+install -D -m 644 update-bootloader.8 %{buildroot}%{_mandir}/man8/update-bootloader.8
+install -D -m 644 kexec-bootloader.8 %{buildroot}%{_mandir}/man8/kexec-bootloader.8
+mkdir -p %{buildroot}/var/log
+touch %{buildroot}/var/log/pbl.log
+
+%post
+echo -n >>/var/log/pbl.log
+chmod 600 /var/log/pbl.log
+
+%files
+%defattr(-, root, root)
+%license COPYING
+%doc %{_mandir}/man8/*
+%doc boot.readme
+%{sbindir}/update-bootloader
+%{sbindir}/pbl
+%{sbindir}/kexec-bootloader
+/usr/lib/bootloader
+%if "%{_distconfdir}" == "/etc"
+%config(noreplace) %{_distconfdir}/logrotate.d/pbl
+%else
+%{_distconfdir}/logrotate.d/pbl
+%endif
+%ghost %attr(0600,root,root) /var/log/pbl.log
+
+%changelog


### PR DESCRIPTION
## Task

To be able to release the latest versions as maintenance update, support both the new `update-bootloader` and the old `perl-Bootloader` package names.

The package content is otherwise identical.