### PR TITLE
explicitly use bash as shell (bsc#1231018)

### DIFF
--- a/pbl.sh
+++ b/pbl.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/sh
+#! /usr/bin/bash
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # This is a (wrapper) script to update the bootloader config.

--- a/run_tests
+++ b/run_tests
@@ -109,6 +109,7 @@ EOF
   done
 
   make install DESTDIR="$test_root"
+  sed -i -e '1s/[^/]*sh/sh/' "$test_root/usr/sbin/pbl"
 }
 
 done_tests ()


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1231018

pbl is compatible to ash, bash, and ksh - but not dash. This causes problems with users having dash as default shell.

## Solution

Explicitly use bash for running pbl. Test cases are still in place to ensure compatibility to ash and ksh, should it ever be useful.