### PR TITLE
bash in SLE15 works differently than in TW; adjust for differences (bsc#1231018)

### DIFF
--- a/grub2/config
+++ b/grub2/config
@@ -7,6 +7,9 @@
 #   bootloader, language
 #
 
+# include common functions
+. "$PBL_INCLUDE/library"
+
 if [ -x /usr/sbin/grub2-mkconfig ] ; then
   if [ -d /boot/grub2 ] ; then
     ( set -x ; /usr/sbin/grub2-mkconfig -o /boot/grub2/grub.cfg )

--- a/grub2/default
+++ b/grub2/default
@@ -7,6 +7,9 @@
 #   bootloader, language
 #
 
+# include common functions
+. "$PBL_INCLUDE/library"
+
 if [ -x /usr/sbin/grub2-set-default ] ; then
   if [ -f /boot/grub2/grubenv ] ; then
     ( set -x ; /usr/sbin/grub2-set-default "$1" )

--- a/grub2/install
+++ b/grub2/install
@@ -15,6 +15,8 @@
 # physical disks then grub is installed only on one (the 'first') of them.
 #
 
+# include common functions
+. "$PBL_INCLUDE/library"
 
 # Usage: prep_partition(disk)
 #

--- a/include/library
+++ b/include/library
@@ -1,3 +1,6 @@
+# get out of POSIX mode in case we are running bash
+unset POSIXLY_CORRECT
+
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # shellquote STRING
 #

--- a/systemd-boot/add-kernel
+++ b/systemd-boot/add-kernel
@@ -11,6 +11,9 @@
 #
 # Add kernel/initrd to boot config.
 
+# include common functions
+. "$PBL_INCLUDE/library"
+
 err=0
 
 if [ -x /usr/bin/sdbootutil ] ; then

--- a/systemd-boot/default
+++ b/systemd-boot/default
@@ -7,6 +7,9 @@
 #   bootloader, language
 #
 
+# include common functions
+. "$PBL_INCLUDE/library"
+
 err=0
 if [ -x /usr/bin/sdbootutil ] ; then
   ( set -x ; sdbootutil set-default "$1" ) || err=1

--- a/systemd-boot/remove-kernel
+++ b/systemd-boot/remove-kernel
@@ -11,6 +11,9 @@
 #
 # Remove kernel/initrd from boot config.
 
+# include common functions
+. "$PBL_INCLUDE/library"
+
 err=0
 if [ -x /usr/bin/kernel-install ] ; then
   ( set -x ; kernel-install remove "$1" ) || err=1


### PR DESCRIPTION
## Task

bash when run as `sh` works differently in SLE15 (bash version 4.4) compared to Tumbleweed (bash version 5.2).

In particular, process substitution (things like `echo <(df)`) is not available in 4.4.

To accomodate for this, unset the `POSIXLY_CORRECT` environment variable to force bash into non-posix mode.