### PR TITLE
provide default settings in cases where kernel and initrd symlinks are missing (bsc#1233956)

### DIFF
--- a/grub2/default-settings
+++ b/grub2/default-settings
@@ -29,12 +29,12 @@ esac
 
 lib_get_cmdline_grub
 
-kernel=$(readlink -f "/boot/$image")
-initrd=$(readlink -f /boot/initrd)
+lib_get_default_kernel_initrd
+
 append=\"$(lib_shellquote "$cmdline")\"
 
-echo "kernel=$kernel" > "$PBL_RESULT"
-echo "initrd=$initrd" >> "$PBL_RESULT"
+echo "kernel=$default_kernel" > "$PBL_RESULT"
+echo "initrd=$default_initrd" >> "$PBL_RESULT"
 echo -n "append=$append" >> "$PBL_RESULT"
 
 exit 0

--- a/include/library
+++ b/include/library
@@ -349,3 +349,59 @@ lib_efi_log_boot_entry ()
   echo "efi_entry.file=$efi_distro_entry_file"
   echo "efi_entry.name=$efi_distro_entry_name"
 }
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# lib_get_default_kernel_initrd
+#
+# Set $default_kernel and $default_initrd to default kernel image and initrd, resp.
+#
+lib_get_default_kernel_initrd ()
+{
+  default_kernel=
+  default_initrd=
+
+  tmp_target=$(uname -m)
+
+  case "$tmp_target" in
+    x86_64|i?86) tmp_image=vmlinuz ;;
+    ppc*) tmp_image=vmlinux ;;
+    s390*) tmp_image=image ;;
+    armv*) tmp_image=zImage ;;
+    aarch64|riscv64) tmp_image=Image ;;
+    *) echo "architecture $tmp_target not supported" ; exit 1
+  esac
+
+  # the default values, also in case nothing is found
+  default_kernel=$(readlink -f "/boot/$tmp_image")
+  default_initrd=$(readlink -f "/boot/initrd")
+
+  # there is a "/boot/<KERNEL>" symlink
+  if [ -e "$default_kernel" ] ; then
+    return
+  fi
+
+  tmp_kernel_version=$(uname -r)
+
+  # try "/boot/<KERNEL-CURRENT_KERNEL_VERSION>"
+  if [ -e "/boot/$tmp_image-$tmp_kernel_version" ] ; then
+    default_kernel=$(readlink -f "/boot/$tmp_image-$tmp_kernel_version")
+    default_initrd=$(readlink -f "/boot/initrd-$tmp_kernel_version")
+    return
+  fi
+
+  # try "/usr/lib/modules/<CURRENT_KERNEL_VERSION>/KERNEL"
+  if [ -e "/usr/lib/modules/$tmp_kernel_version/$tmp_image" ] ; then
+    default_kernel=$(readlink -f "/usr/lib/modules/$tmp_kernel_version/$tmp_image")
+    default_initrd=$(readlink -f "/boot/initrd-$tmp_kernel_version")
+    return
+  fi
+
+  # try newest (according to file date) "/boot/<KERNEL-VERSION>" entry
+  for tmp_kernel in $(ls -t /boot/$tmp_image-* 2>/dev/null) ; do
+    tmp_kernel_version=${tmp_kernel#*-}
+    default_kernel=$(readlink -f "/boot/$tmp_image-$tmp_kernel_version")
+    default_initrd=$(readlink -f "/boot/initrd-$tmp_kernel_version")
+    return
+  done
+}

--- a/run_tests
+++ b/run_tests
@@ -22,11 +22,14 @@ busybox_programs="\
   /usr/bin/cut\
   /usr/bin/dirname\
   /usr/bin/grep\
+  /usr/bin/ln\
   /usr/bin/ls\
+  /usr/bin/mkdir\
   /usr/bin/mktemp\
   /usr/bin/readlink\
   /usr/bin/rm\
   /usr/bin/sed\
+  /usr/bin/sleep\
   /usr/bin/tr\
 "
 dummy_programs="\

--- a/systemd-boot/default-settings
+++ b/systemd-boot/default-settings
@@ -15,34 +15,14 @@ append=\"$(lib_shellquote "$cmdline")\"
 
 err=0
 if [ -x /usr/bin/bootctl ] ; then
-  kernel=$(bootctl status | grep linux: | cut -d ':' -f 2 | tr -ds ' ' '/')
-  initrd=$(bootctl status | grep initrd: | cut -d ':' -f 2 | tr -ds ' ' '/')
+  default_kernel=$(bootctl status | grep linux: | cut -d ':' -f 2 | tr -ds ' ' '/')
+  default_initrd=$(bootctl status | grep initrd: | cut -d ':' -f 2 | tr -ds ' ' '/')
 else
-  target=$(uname -m)
-
-  case "$target" in
-    x86_64|i?86)
-      image=vmlinuz ;;
-    ppc*)
-      image=vmlinux ;;
-    s390*)
-      image=image ;;
-    armv*)
-      image=zImage ;;
-    aarch64|riscv64)
-      image=Image ;;
-    *)
-      echo "Architecture $target not supported."
-      err=1
-  esac
-
-  # FIXME: this is not correct but gives a possibly useful fallback
-  kernel=$(readlink -f "/boot/$image")
-  initrd=$(readlink -f "/boot/initrd")
+  lib_get_default_kernel_initrd
 fi
 
-echo "kernel=$kernel" > "$PBL_RESULT"
-echo "initrd=$initrd" >> "$PBL_RESULT"
+echo "kernel=$default_kernel" > "$PBL_RESULT"
+echo "initrd=$default_initrd" >> "$PBL_RESULT"
 echo -n "append=$append" >> "$PBL_RESULT"
 
 exit $err

--- a/tests/0100_kexec-bootloader_x86_64/script
+++ b/tests/0100_kexec-bootloader_x86_64/script
@@ -1,4 +1,6 @@
 export TEST_ARCH=x86_64
+export TEST_KERNEL_VERSION=6.7.8-9-default
+
 run pbl --loader grub2
 run kexec-bootloader --debug
 export TEST_KEXEC_EXIT=42

--- a/tests/1200_grub2_x86_64_default-settings/output.bash.ref
+++ b/tests/1200_grub2_x86_64_default-settings/output.bash.ref
@@ -3,3 +3,19 @@ kernel=/boot/vmlinuz
 initrd=/boot/initrd
 append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
 [✔] pbl --default-settings
+kernel=/boot/vmlinuz-5.6.7-8-foobar
+initrd=/boot/initrd-5.6.7-8-foobar
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+[✔] pbl --default-settings
+kernel=/usr/lib/modules/6.7.8-9-default/vmlinuz
+initrd=/boot/initrd-6.7.8-9-default
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+[✔] pbl --default-settings
+kernel=/boot/vmlinuz-6.7.8-9-default
+initrd=/boot/initrd-6.7.8-9-default
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+[✔] pbl --default-settings
+kernel=/boot/vmlinuz-5.6.7-7-foobar
+initrd=/boot/initrd-5.6.7-7-foobar
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+[✔] pbl --default-settings

--- a/tests/1200_grub2_x86_64_default-settings/output.busybox.ref
+++ b/tests/1200_grub2_x86_64_default-settings/output.busybox.ref
@@ -3,3 +3,21 @@ kernel=/boot/vmlinuz
 initrd=/boot/initrd
 append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
 [✔] pbl --default-settings
+sleep: invalid number '0.1'
+sleep: invalid number '0.1'
+kernel=/boot/vmlinuz-5.6.7-6-foobar
+initrd=/boot/initrd-5.6.7-6-foobar
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+[✔] pbl --default-settings
+kernel=/usr/lib/modules/6.7.8-9-default/vmlinuz
+initrd=/boot/initrd-6.7.8-9-default
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+[✔] pbl --default-settings
+kernel=/boot/vmlinuz-6.7.8-9-default
+initrd=/boot/initrd-6.7.8-9-default
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+[✔] pbl --default-settings
+kernel=/boot/vmlinuz-5.6.7-7-foobar
+initrd=/boot/initrd-5.6.7-7-foobar
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+[✔] pbl --default-settings

--- a/tests/1200_grub2_x86_64_default-settings/output.ksh.ref
+++ b/tests/1200_grub2_x86_64_default-settings/output.ksh.ref
@@ -3,3 +3,19 @@ kernel=/boot/vmlinuz
 initrd=/boot/initrd
 append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
 [✔] pbl --default-settings
+kernel=/boot/vmlinuz-5.6.7-8-foobar
+initrd=/boot/initrd-5.6.7-8-foobar
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+[✔] pbl --default-settings
+kernel=/usr/lib/modules/6.7.8-9-default/vmlinuz
+initrd=/boot/initrd-6.7.8-9-default
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+[✔] pbl --default-settings
+kernel=/boot/vmlinuz-6.7.8-9-default
+initrd=/boot/initrd-6.7.8-9-default
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+[✔] pbl --default-settings
+kernel=/boot/vmlinuz-5.6.7-7-foobar
+initrd=/boot/initrd-5.6.7-7-foobar
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+[✔] pbl --default-settings

--- a/tests/1200_grub2_x86_64_default-settings/pbl.log.bash.ref
+++ b/tests/1200_grub2_x86_64_default-settings/pbl.log.bash.ref
@@ -7,3 +7,35 @@ kernel=/boot/vmlinuz
 initrd=/boot/initrd
 append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
 <<<<<<<<<<<<<<<<
+2023-11-01 23:59:58 <1> pbl-0: bootloader = grub2
+2023-11-01 23:59:58 <1> pbl-0: '/usr/lib/bootloader/grub2/default-settings' = 0, output:
+2023-11-01 23:59:58 <1> pbl-0: result:
+>>>>>>>>>>>>>>>>
+kernel=/boot/vmlinuz-5.6.7-8-foobar
+initrd=/boot/initrd-5.6.7-8-foobar
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+<<<<<<<<<<<<<<<<
+2023-11-01 23:59:58 <1> pbl-0: bootloader = grub2
+2023-11-01 23:59:58 <1> pbl-0: '/usr/lib/bootloader/grub2/default-settings' = 0, output:
+2023-11-01 23:59:58 <1> pbl-0: result:
+>>>>>>>>>>>>>>>>
+kernel=/usr/lib/modules/6.7.8-9-default/vmlinuz
+initrd=/boot/initrd-6.7.8-9-default
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+<<<<<<<<<<<<<<<<
+2023-11-01 23:59:58 <1> pbl-0: bootloader = grub2
+2023-11-01 23:59:58 <1> pbl-0: '/usr/lib/bootloader/grub2/default-settings' = 0, output:
+2023-11-01 23:59:58 <1> pbl-0: result:
+>>>>>>>>>>>>>>>>
+kernel=/boot/vmlinuz-6.7.8-9-default
+initrd=/boot/initrd-6.7.8-9-default
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+<<<<<<<<<<<<<<<<
+2023-11-01 23:59:58 <1> pbl-0: bootloader = grub2
+2023-11-01 23:59:58 <1> pbl-0: '/usr/lib/bootloader/grub2/default-settings' = 0, output:
+2023-11-01 23:59:58 <1> pbl-0: result:
+>>>>>>>>>>>>>>>>
+kernel=/boot/vmlinuz-5.6.7-7-foobar
+initrd=/boot/initrd-5.6.7-7-foobar
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+<<<<<<<<<<<<<<<<

--- a/tests/1200_grub2_x86_64_default-settings/pbl.log.busybox.ref
+++ b/tests/1200_grub2_x86_64_default-settings/pbl.log.busybox.ref
@@ -7,3 +7,35 @@ kernel=/boot/vmlinuz
 initrd=/boot/initrd
 append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
 <<<<<<<<<<<<<<<<
+2023-11-01 23:59:58 <1> pbl-0: bootloader = grub2
+2023-11-01 23:59:58 <1> pbl-0: '/usr/lib/bootloader/grub2/default-settings' = 0, output:
+2023-11-01 23:59:58 <1> pbl-0: result:
+>>>>>>>>>>>>>>>>
+kernel=/boot/vmlinuz-5.6.7-6-foobar
+initrd=/boot/initrd-5.6.7-6-foobar
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+<<<<<<<<<<<<<<<<
+2023-11-01 23:59:58 <1> pbl-0: bootloader = grub2
+2023-11-01 23:59:58 <1> pbl-0: '/usr/lib/bootloader/grub2/default-settings' = 0, output:
+2023-11-01 23:59:58 <1> pbl-0: result:
+>>>>>>>>>>>>>>>>
+kernel=/usr/lib/modules/6.7.8-9-default/vmlinuz
+initrd=/boot/initrd-6.7.8-9-default
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+<<<<<<<<<<<<<<<<
+2023-11-01 23:59:58 <1> pbl-0: bootloader = grub2
+2023-11-01 23:59:58 <1> pbl-0: '/usr/lib/bootloader/grub2/default-settings' = 0, output:
+2023-11-01 23:59:58 <1> pbl-0: result:
+>>>>>>>>>>>>>>>>
+kernel=/boot/vmlinuz-6.7.8-9-default
+initrd=/boot/initrd-6.7.8-9-default
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+<<<<<<<<<<<<<<<<
+2023-11-01 23:59:58 <1> pbl-0: bootloader = grub2
+2023-11-01 23:59:58 <1> pbl-0: '/usr/lib/bootloader/grub2/default-settings' = 0, output:
+2023-11-01 23:59:58 <1> pbl-0: result:
+>>>>>>>>>>>>>>>>
+kernel=/boot/vmlinuz-5.6.7-7-foobar
+initrd=/boot/initrd-5.6.7-7-foobar
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+<<<<<<<<<<<<<<<<

--- a/tests/1200_grub2_x86_64_default-settings/pbl.log.ksh.ref
+++ b/tests/1200_grub2_x86_64_default-settings/pbl.log.ksh.ref
@@ -7,3 +7,35 @@ kernel=/boot/vmlinuz
 initrd=/boot/initrd
 append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
 <<<<<<<<<<<<<<<<
+2023-11-01 23:59:58 <1> pbl-0: bootloader = grub2
+2023-11-01 23:59:58 <1> pbl-0: '/usr/lib/bootloader/grub2/default-settings' = 0, output:
+2023-11-01 23:59:58 <1> pbl-0: result:
+>>>>>>>>>>>>>>>>
+kernel=/boot/vmlinuz-5.6.7-8-foobar
+initrd=/boot/initrd-5.6.7-8-foobar
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+<<<<<<<<<<<<<<<<
+2023-11-01 23:59:58 <1> pbl-0: bootloader = grub2
+2023-11-01 23:59:58 <1> pbl-0: '/usr/lib/bootloader/grub2/default-settings' = 0, output:
+2023-11-01 23:59:58 <1> pbl-0: result:
+>>>>>>>>>>>>>>>>
+kernel=/usr/lib/modules/6.7.8-9-default/vmlinuz
+initrd=/boot/initrd-6.7.8-9-default
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+<<<<<<<<<<<<<<<<
+2023-11-01 23:59:58 <1> pbl-0: bootloader = grub2
+2023-11-01 23:59:58 <1> pbl-0: '/usr/lib/bootloader/grub2/default-settings' = 0, output:
+2023-11-01 23:59:58 <1> pbl-0: result:
+>>>>>>>>>>>>>>>>
+kernel=/boot/vmlinuz-6.7.8-9-default
+initrd=/boot/initrd-6.7.8-9-default
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+<<<<<<<<<<<<<<<<
+2023-11-01 23:59:58 <1> pbl-0: bootloader = grub2
+2023-11-01 23:59:58 <1> pbl-0: '/usr/lib/bootloader/grub2/default-settings' = 0, output:
+2023-11-01 23:59:58 <1> pbl-0: result:
+>>>>>>>>>>>>>>>>
+kernel=/boot/vmlinuz-5.6.7-7-foobar
+initrd=/boot/initrd-5.6.7-7-foobar
+append="mitigations=off quiet foo=\"foo  bar\" nosimplefb=1"
+<<<<<<<<<<<<<<<<

--- a/tests/1200_grub2_x86_64_default-settings/script
+++ b/tests/1200_grub2_x86_64_default-settings/script
@@ -1,3 +1,32 @@
 export TEST_ARCH=x86_64
+export TEST_KERNEL_VERSION=6.7.8-9-default
+
 run pbl --loader grub2
+
+# ***  the following tests are ordered least priority first  ***
+
+# fallback result (nothing in /boot)
+run pbl --default-settings
+
+# if there are several kernels in /boot, choose latest one
+echo > /boot/vmlinuz-5.6.7-6-foobar
+sleep 0.1
+echo > /boot/vmlinuz-5.6.7-7-foobar
+sleep 0.1
+echo > /boot/vmlinuz-5.6.7-8-foobar
+run pbl --default-settings
+
+# if there's a kernel matching the running kernel in /usr/lib, choose it
+mkdir -p /usr/lib/modules/$TEST_KERNEL_VERSION
+echo > /usr/lib/modules/$TEST_KERNEL_VERSION/vmlinuz
+run pbl --default-settings
+
+# if there's a kernel matching the running kernel in /boot, choose it
+echo > /boot/vmlinuz-$TEST_KERNEL_VERSION
+run pbl --default-settings
+
+# if there are "<KERNEL_IMAGE>" and "initrd" symlinks, choose them
+ln -s vmlinuz-5.6.7-7-foobar /boot/vmlinuz
+ln -s initrd-5.6.7-7-foobar /boot/initrd
+echo > /boot/initrd-5.6.7-7-foobar
 run pbl --default-settings

--- a/tests/1400_grub2_x86_64_add-option/script
+++ b/tests/1400_grub2_x86_64_add-option/script
@@ -1,4 +1,6 @@
 export TEST_ARCH=x86_64
+export TEST_KERNEL_VERSION=6.7.8-9-default
+
 run pbl --loader grub2
 run pbl --add-option 'foo="bar  zap"'
 run pbl --add-option quiet=99

--- a/tests/1500_grub2_x86_64_del-option/script
+++ b/tests/1500_grub2_x86_64_del-option/script
@@ -1,4 +1,6 @@
 export TEST_ARCH=x86_64
+export TEST_KERNEL_VERSION=6.7.8-9-default
+
 run pbl --loader grub2
 run pbl --del-option quiet=on
 run pbl --del-option quiet=off

--- a/tests/3200_grub2-bls_x86_64_default-settings/script
+++ b/tests/3200_grub2-bls_x86_64_default-settings/script
@@ -1,6 +1,10 @@
 export TEST_ARCH=x86_64
+export TEST_KERNEL_VERSION=6.7.8-9-default
+
 run pbl --loader grub2-bls
+
 run pbl --default-settings
+
 # simulate missing bootctl
 chmod a-x /usr/bin/bootctl
 run pbl --default-settings

--- a/tests/4200_systemd-boot_x86_64_default-settings/script
+++ b/tests/4200_systemd-boot_x86_64_default-settings/script
@@ -1,6 +1,10 @@
 export TEST_ARCH=x86_64
+export TEST_KERNEL_VERSION=6.7.8-9-default
+
 run pbl --loader systemd-boot
+
 run pbl --default-settings
+
 # simulate missing bootctl
 chmod a-x /usr/bin/bootctl
 run pbl --default-settings

--- a/tests/data/usr/bin/uname
+++ b/tests/data/usr/bin/uname
@@ -8,6 +8,14 @@ if [ "$1" = "-m" ] ; then
     echo "TEST_ARCH not set" >&2
     exit 1
   fi
+elif [ "$1" = "-r" ] ; then
+  if [ -n "$TEST_KERNEL_VERSION" ] ; then
+    echo "$TEST_KERNEL_VERSION"
+    exit 0
+  else
+    echo "TEST_KERNEL_VERSION not set" >&2
+    exit 1
+  fi
 else
   echo "unsupported uname option" >&2
   exit 1


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1233956

Don't rely on `/boot/initrd` and `/boot/<KERNEL>` when providing default settings.