### PR TITLE
really enforce bash everywhere now (bsc#1231018)

### DIFF
--- a/kexec-bootloader
+++ b/kexec-bootloader
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#! /usr/bin/sh
 
 # Print help text and exit.
 #
@@ -39,7 +39,7 @@ done
   exit 1
 }
 
-for i in $(< /proc/cmdline) ; do
+for i in $(cat /proc/cmdline) ; do
   case $i in
     root=*) root=$i ; break ;;
   esac

--- a/pbl.sh
+++ b/pbl.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#! /usr/bin/sh
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # This is a (wrapper) script to update the bootloader config.

--- a/run_tests
+++ b/run_tests
@@ -111,7 +111,7 @@ EOF
    chmod 755 "$test_root/$p"
   done
 
-  make install DESTDIR="$test_root"
+  make install DESTDIR="$test_root" INTERPRETER=sh
   sed -i -e '1s/[^/]*sh/sh/' "$test_root/usr/sbin/pbl"
 }
 

--- a/u-boot/config
+++ b/u-boot/config
@@ -1,4 +1,4 @@
-#!/bin/bash
+#! /usr/bin/sh
 
 # Settings from /etc/sysconfig/filename are available as environment vars
 # with the name 'SYS__FILENAME__KEY' (filename converted to upper case).


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1231018
- https://github.com/openSUSE/perl-bootloader/pull/187

There were some places left where `/usr/bin/sh` was used as shell interpreter.

Change install script to enforce uniform shell in all places.

## Bonus

- fix incompatibility with `ash` in `kexec-bootloader`
- keep symlinked scripts as symlinks when installed