### PR TITLE
avoid spurious warning messages when parsing /etc/default/grub (bsc#1246373, bsc#1245323)

### DIFF
--- a/pbl.sh
+++ b/pbl.sh
@@ -255,12 +255,6 @@ set_log ()
 #
 set_loader ()
 {
-  if [ "$1" = grub2-bls -a "$DEFAULT__GRUB_ENABLE_BLSCFG" = false ] ; then
-    lib_set_config "/etc/default/grub" "GRUB_ENABLE_BLSCFG" "true"
-  elif [ \( "$1" = grub2-efi -o "$1" = grub2 \) -a "$DEFAULT__GRUB_ENABLE_BLSCFG" = true ] ; then
-    lib_set_config "/etc/default/grub" "GRUB_ENABLE_BLSCFG" "false"
-  fi
-
   lib_set_config "$sysconfig_dir/bootloader" "LOADER_TYPE" "$1"
 
   return $?
@@ -312,16 +306,8 @@ export PBL_INCLUDE
 read_sysconfig "bootloader";
 read_sysconfig "language";
 
-read_config "/etc/default/grub" "DEFAULT"
-
 loader="$SYS__BOOTLOADER__LOADER_TYPE"
 lang="$SYS__LANGUAGE__RC_LANG"
-
-if [ "$loader" = grub2-efi -a "$DEFAULT__GRUB_ENABLE_BLSCFG" = true ] ; then
-  loader=grub2-bls
-elif [ "$loader" = grub2-bls -a "$DEFAULT__GRUB_ENABLE_BLSCFG" = false ] ; then
-  loader=grub2-efi
-fi
 
 set_log "$logfile"
 


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1246373
- https://bugzilla.suse.com/show_bug.cgi?id=1245323

For sufficiently complex `/etc/default/grub` files some spurious warning messages could show up.

That was caused by some preliminary parsing step that is no longer needed.

This patch removes that code.