### PR TITLE
Implement config for BLS

### DIFF
--- a/systemd-boot/config
+++ b/systemd-boot/config
@@ -10,4 +10,11 @@
 # include common functions
 . "$PBL_INCLUDE/library"
 
-echo "nothing to do, really"
+if [ -x /usr/bin/sdbootutil ] ; then
+  ( set -x ; sdbootutil update-all-entries ) || err=1
+elif [ -x /usr/bin/kernel-install ] ; then
+  ( set -x ; kernel-install add-all ) || err=1
+else
+  echo "Found neither sdbootutil nor kernel-install"
+  err=1
+fi


### PR DESCRIPTION
That calls sdbootutil resp. kernel-install in a way that makes sure the BLS entries contain the new /etc/kernel/cmdline. The following sequence works again as expected:

update-bootloader --add-option foo=bar --config

CC @aplanas 