### PR TITLE
switch to r/w if /boot/efi is r/o

### DIFF
--- a/grub2-efi/install
+++ b/grub2-efi/install
@@ -124,6 +124,8 @@ if [ "$SYS__BOOTLOADER__UPDATE_NVRAM" = "no" ] ; then
   append="$append --no-nvram"
 fi
 
+lib_switch_efi_mount_dir_ro_rw pre
+
 if [ "$SYS__BOOTLOADER__SECURE_BOOT" = "yes" -a -x /usr/sbin/shim-install ] ; then
   ( set -x ; /usr/sbin/shim-install --config-file=/boot/grub2/grub.cfg $append )
 elif [ -x /usr/sbin/grub2-install ] ; then
@@ -151,6 +153,7 @@ else
   exit 1
 fi
 
+lib_switch_efi_mount_dir_ro_rw post
 err=$?
 
 lib_efi_log_boot_entry

--- a/include/library
+++ b/include/library
@@ -405,3 +405,30 @@ lib_get_default_kernel_initrd ()
     return
   done
 }
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# lib_switch_efi_mount_dir_ro_rw
+#
+# Switch $efi_mount_dir filesystem ro/rw modes
+#
+lib_switch_efi_mount_dir_ro_rw ()
+{
+  local action=$1
+
+  lib_get_efi_mount_dir
+
+  case "$action" in
+    pre)
+      if findmnt -no OPTIONS "$efi_mount_dir" | tr ',' '\n' | grep -q '^ro$' ; then
+        mount -o remount,rw "$efi_mount_dir"
+      fi
+      ;;
+    post)
+      mode=$(awk -v efi_mount_dir="$efi_mount_dir" \
+        '$2 == efi_mount_dir { print $4 }' /etc/fstab | tr ',' '\n' | grep '^ro')
+      if [ -n "$mode" ]; then
+        mount -o remount,"$mode" "$efi_mount_dir"
+      fi
+      ;;
+  esac
+}


### PR DESCRIPTION
A customer asked me about a solution if /boot/efi is r/o. What do you think?

Tested on SL-Micro 6.2 x86_64 only.